### PR TITLE
Rename references to the old repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Checkout cri-dockerd
         uses: actions/checkout@v2
         with:
-          repository: evol262/cri-dockerd
-          path: src/github.com/evol262/cri-dockerd
+          repository: Mirantis/cri-dockerd
+          path: src/github.com/Mirantis/cri-dockerd
 
       - name: Install docker
         shell: bash
@@ -67,7 +67,7 @@ jobs:
           sudo service docker restart
 
       - name: Build cri-dockerd
-        working-directory: src/github.com/evol262/cri-dockerd
+        working-directory: src/github.com/Mirantis/cri-dockerd
         run: |
           # make deb
           make rpm

--- a/.github/workflows/local-up.yml
+++ b/.github/workflows/local-up.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Checkout cri-dockerd
         uses: actions/checkout@v2
         with:
-          repository: evol262/cri-dockerd
-          path: src/github.com/evol262/cri-dockerd
+          repository: Mirantis/cri-dockerd
+          path: src/github.com/Mirantis/cri-dockerd
 
       - name: Checkout test-infra for kubetest
         uses: actions/checkout@v2
@@ -45,7 +45,7 @@ jobs:
           path: src/k8s.io/test-infra
 
       - name: Build cri-dockerd
-        working-directory: src/github.com/evol262/cri-dockerd
+        working-directory: src/github.com/Mirantis/cri-dockerd
         run: |
           go install .
           sudo mv $GOPATH/bin/cri-dockerd /usr/local/bin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Checkout cri-dockerd
         uses: actions/checkout@v2
         with:
-          repository: evol262/cri-dockerd
-          path: src/github.com/evol262/cri-dockerd
+          repository: Mirantis/cri-dockerd
+          path: src/github.com/Mirantis/cri-dockerd
 
       - name: Install docker
         shell: bash
@@ -81,7 +81,7 @@ jobs:
           sudo mv $(pwd)/_output/crictl /usr/local/bin
 
       - name: Build cri-dockerd
-        working-directory: src/github.com/evol262/cri-dockerd
+        working-directory: src/github.com/Mirantis/cri-dockerd
         run: |
           go install .
           sudo mv $GOPATH/bin/cri-dockerd /usr/local/bin

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/evol262/cri-dockerd
+module github.com/Mirantis/cri-dockerd
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/evol262/cri-dockerd/pkg/app"
+	"github.com/Mirantis/cri-dockerd/pkg/app"
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/component-base/logs"
 )

--- a/packaging/deb/build-deb
+++ b/packaging/deb/build-deb
@@ -7,8 +7,8 @@ mkdir -p /root/build-deb/app
 tar -C /root/build-deb -xzf /sources/app.tgz
 
 # link them to their canonical path
-mkdir -p /go/src/github.com/evol262
-ln -snf /root/build-deb/app /go/src/github.com/evol262/cri-docker
+mkdir -p /go/src/github.com/Mirantis
+ln -snf /root/build-deb/app /go/src/github.com/Mirantis/cri-docker
 
 EPOCH="${EPOCH:-}"
 EPOCH_SEP=""

--- a/packaging/deb/common/rules
+++ b/packaging/deb/common/rules
@@ -19,7 +19,7 @@ override_dh_strip:
 	# Go has lots of problems with stripping, so just don't
 
 override_dh_auto_install:
-	install -D -m 0755 /go/src/github.com/evol262/cri-docker/cri-dockerd debian/cri-docker/usr/bin/cri-dockerd
+	install -D -m 0755 /go/src/github.com/Mirantis/cri-docker/cri-dockerd debian/cri-docker/usr/bin/cri-dockerd
 	install -D -m 0644 /sources/cri-docker.service debian/cri-docker/lib/systemd/system/cri-docker.service
 	install -D -m 0644 /sources/cri-docker.socket debian/cri-docker/lib/systemd/system/cri-docker.socket
 

--- a/packaging/rpm/SPECS/cri-docker.spec
+++ b/packaging/rpm/SPECS/cri-docker.spec
@@ -61,8 +61,8 @@ cri-docker is a lightweight implementation of the CRI specification which talks 
 
 %build
 export CRI_DOCKER_GITCOMMIT=%{_gitcommit}
-mkdir -p /go/src/github.com/evol262
-ln -s /root/rpmbuild/BUILD/src/app /go/src/github.com/evol262/cri-docker
+mkdir -p /go/src/github.com/Mirantis
+ln -s /root/rpmbuild/BUILD/src/app /go/src/github.com/Mirantis/cri-docker
 cd /root/rpmbuild/BUILD/src/app
 go get && go build
 

--- a/packaging/windows/Makefile
+++ b/packaging/windows/Makefile
@@ -4,7 +4,7 @@ APP_DIR:=$(realpath $(CURDIR)/../../app)
 GO_BASE_IMAGE=golang
 WINDOWS_BUILDER?=windows-engine-builder
 GOPATH=C:\go
-CRI_DOCKER_GOPATH=C:\gopath\src\github.com\evol262
+CRI_DOCKER_GOPATH=C:\gopath\src\github.com\Mirantis
 CRI_DOCKER_GITCOMMIT?=$(shell git -C $APP_DIR rev-parse --short HEAD)
 
 clean:

--- a/pkg/app/options/container_runtime.go
+++ b/pkg/app/options/container_runtime.go
@@ -20,7 +20,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/evol262/cri-dockerd/pkg/app/config"
+	"github.com/Mirantis/cri-dockerd/pkg/app/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/app/options/options.go
+++ b/pkg/app/options/options.go
@@ -20,7 +20,7 @@ package options
 import (
 	"runtime"
 
-	"github.com/evol262/cri-dockerd/pkg/app/config"
+	"github.com/Mirantis/cri-dockerd/pkg/app/config"
 
 	"github.com/spf13/pflag"
 )

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -19,13 +19,13 @@ package app
 import (
 	"fmt"
 	"net/url"
-	"github.com/evol262/cri-dockerd/pkg/app/options"
+	"github.com/Mirantis/cri-dockerd/pkg/app/options"
 	"k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/version/verflag"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/klog"
-	"github.com/evol262/cri-dockerd/dockershim"
-	dockerremote "github.com/evol262/cri-dockerd/dockershim/remote"
+	"github.com/Mirantis/cri-dockerd/dockershim"
+	dockerremote "github.com/Mirantis/cri-dockerd/dockershim/remote"
 	"k8s.io/kubernetes/pkg/kubelet/cri/streaming"
 	utilflag "k8s.io/component-base/cli/flag"
 


### PR DESCRIPTION
In github workflows, packaging, and all go code, use the new
repo now that it's merged