### PR TITLE
Add support for fd:// for socket activation

### DIFF
--- a/dockershim/remote/docker_server.go
+++ b/dockershim/remote/docker_server.go
@@ -20,7 +20,9 @@ package remote
 
 import (
 	"fmt"
+	"net"
 	"os"
+	"strings"
 
 	"google.golang.org/grpc"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
@@ -51,6 +53,18 @@ func NewDockerServer(endpoint string, s dockershim.CRIService) *DockerServer {
 	}
 }
 
+func getListener(addr string) (net.Listener, error) {
+	addrSlice := strings.SplitN(addr, "://", 2)
+	proto := addrSlice[0]
+	listenAddr := addrSlice[1]
+	switch proto {
+	case "fd":
+		return listenFD(listenAddr)
+	default:
+		return util.CreateListener(addr)
+	}
+}
+
 // Start starts the dockershim grpc server.
 func (s *DockerServer) Start() error {
 	// Start the internal service.
@@ -60,7 +74,7 @@ func (s *DockerServer) Start() error {
 	}
 
 	klog.V(2).InfoS("Start dockershim grpc server")
-	l, err := util.CreateListener(s.endpoint)
+	l, err := getListener(s.endpoint)
 	if err != nil {
 		return fmt.Errorf("failed to listen on %q: %v", s.endpoint, err)
 	}

--- a/dockershim/remote/docker_server_unix.go
+++ b/dockershim/remote/docker_server_unix.go
@@ -1,0 +1,34 @@
+// +build !dockerless !windows
+
+package remote
+
+import (
+	"net"
+
+	"github.com/coreos/go-systemd/v22/activation"
+	"github.com/pkg/errors"
+)
+
+func listenFD(addr string) (net.Listener, error) {
+	var (
+		err       error
+		listeners []net.Listener
+	)
+	// socket activation
+	listeners, err = activation.Listeners()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(listeners) == 0 {
+		return nil, errors.New("no sockets found via socket activation: make sure the service was started by systemd")
+	}
+
+	// default to first fd
+	if addr == "" {
+		return listeners[0], nil
+	}
+
+	//TODO: systemd fd selection (default is 3)
+	return nil, errors.New("not supported yet")
+}

--- a/dockershim/remote/docker_server_windows.go
+++ b/dockershim/remote/docker_server_windows.go
@@ -1,0 +1,13 @@
+// +build !dockerless windows
+
+package server
+
+import (
+	"net"
+
+	"github.com/pkg/errors"
+)
+
+func listenFD(addr string) (net.Listener, error) {
+	return nil, errors.New("listening server on fd not supported on windows")
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/imdario/mergo v0.3.7 // indirect

--- a/packaging/systemd/cri-docker.service
+++ b/packaging/systemd/cri-docker.service
@@ -8,7 +8,7 @@ Requires=cri-docker.socket
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/cri-dockerd --v=10 --networkplugin="" --logtostderr
+ExecStart=/usr/bin/cri-dockerd --container-runtime-endpoint fd:// --network-plugin=""
 ExecReload=/bin/kill -s HUP $MAINPID
 TimeoutSec=0
 RestartSec=2

--- a/packaging/systemd/cri-docker.socket
+++ b/packaging/systemd/cri-docker.socket
@@ -3,7 +3,7 @@ Description=CRI Docker Socket for the API
 PartOf=cri-docker.service
 
 [Socket]
-ListenStream=/var/run/cri-docker.sock
+ListenStream=%t/cri-docker.sock
 SocketMode=0660
 SocketUser=root
 SocketGroup=docker


### PR DESCRIPTION

This fixes the issue with the `cri-docker.service` listening on the **wrong** unix socket.

Now it works:

```console
$ sudo crictl version
Version:  0.1.0
RuntimeName:  docker
RuntimeVersion:  20.10.8
RuntimeApiVersion:  1.41.0
```

/etc/crictl.yaml
```
runtime-endpoint: "unix:///var/run/cri-docker.sock"
image-endpoint: "unix:///var/run/cri-docker.sock"
```


It also fixes a warning with `cri-docker.socket` due to using legacy syntax for paths:

`ListenStream= references a path below legacy directory /var/run/,
updating /var/run/cri-docker.sock → /run/cri-docker.sock; please update the unit file accordingly.`

Closes #7 