### PR TITLE
Set version info dynamically at build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 APP_DIR:=$(CURDIR)/src
 PACKAGING_DIR:=$(CURDIR)/packaging
-VERSION=$(shell cat VERSION)
+
+export VERSION=$(shell (git describe --abbrev=0 --tags | sed -e 's/v//') || echo $(cat VERSION)-$(git log -1 --pretty='%h'))
+BUILDTIME=`date +%FT%T%z`
+PRERELEASE=`grep -q dev <<< "${VERSION}" && echo "pre" || echo ""`
+GITCOMMIT=`git log -1 --pretty='%h'`
+export LDFLAGS=-ldflags "-X github.com/Mirantis/cri-dockerd/version.Version=${VERSION} -X github.com/Mirantis/cri-dockerd/version.PreRelease=${PRERELEASE} -X github.com/Mirantis/cri-dockerd/version.BuildTime=${BUILDTIME} -X github.com/Mirantis/cri-dockerd/version.GitCommit=${GITCOMMIT}"
 
 .PHONY: help
 help: ## show make targets
@@ -8,27 +13,27 @@ help: ## show make targets
 
 .PHONY: deb
 deb: ## build deb packages
-	$(MAKE) VERSION=$(VERSION) APP_DIR=$(APP_DIR) -C $(PACKAGING_DIR) deb
+	$(MAKE) APP_DIR=$(APP_DIR) -C $(PACKAGING_DIR) deb
 
 .PHONY: rpm
 rpm: ## build rpm packages
-	$(MAKE) VERSION=$(VERSION) APP_DIR=$(APP_DIR)  -C $(PACKAGING_DIR) rpm
+	$(MAKE) APP_DIR=$(APP_DIR) -C $(PACKAGING_DIR) rpm
 
 .PHONY: static
 static: ## build static packages
-	$(MAKE) VERSION=$(VERSION) APP_DIR=$(APP_DIR) -C $(PACKAGING_DIR) static
+	$(MAKE) APP_DIR=$(APP_DIR) -C $(PACKAGING_DIR) static
 
 .PHONY: static-linux
 static-linux: ## build static packages
-	$(MAKE) VERSION=$(VERSION) APP_DIR=$(APP_DIR) -C $(PACKAGING_DIR) static-linux
+	$(MAKE) APP_DIR=$(APP_DIR) -C $(PACKAGING_DIR) static-linux
 
 .PHONY: cross-mac
 cross-mac: ## build static packages
-	$(MAKE) VERSION=$(VERSION) APP_DIR=$(APP_DIR) -C $(PACKAGING_DIR) cross-mac
+	$(MAKE) APP_DIR=$(APP_DIR) -C $(PACKAGING_DIR) cross-mac
 
 .PHONY: cross-win
 cross-win: ## build static packages
-	$(MAKE) VERSION=$(VERSION) APP_DIR=$(APP_DIR) -C $(PACKAGING_DIR) cross-win
+	$(MAKE) APP_DIR=$(APP_DIR) -C $(PACKAGING_DIR) cross-win
 
 .PHONY: clean
 clean: ## clean the build artifacts

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -1,7 +1,6 @@
 include common.mk
 
 APP_DIR:=$(realpath $(CURDIR)/../src)
-STATIC_VERSION:=$(shell static/gen-static-ver $(VERSION))
 
 # Taken from: https://www.cmcrossroads.com/article/printing-value-makefile-variable
 print-%  : ; @echo $($*)
@@ -18,27 +17,27 @@ clean: ## remove build artifacts
 
 .PHONY: rpm
 rpm: ## build rpm packages
-	$(MAKE) -C $@ VERSION=$(VERSION) APP_DIR=$(APP_DIR) GO_VERSION=$(GO_VERSION) rpm
+	$(MAKE) -C $@ APP_DIR=$(APP_DIR) GO_VERSION=$(GO_VERSION) rpm
 
 .PHONY: deb
 deb: ## build deb packages
-	$(MAKE) -C $@ VERSION=$(VERSION) APP_DIR=$(APP_DIR) GO_VERSION=$(GO_VERSION) deb
+	$(MAKE) -C $@ APP_DIR=$(APP_DIR) GO_VERSION=$(GO_VERSION) deb
 
 .PHONY: static
 static: DOCKER_BUILD_PKGS:=static-linux cross-mac cross-win cross-arm
 static: ## build static-compiled packages
 	for p in $(DOCKER_BUILD_PKGS); do \
-		$(MAKE) -C $@ VERSION=$(VERSION) APP_DIR=$(APP_DIR) GO_VERSION=$(GO_VERSION) $${p} || exit 1; \
+		$(MAKE) -C $@ APP_DIR=$(APP_DIR) GO_VERSION=$(GO_VERSION) $${p} || exit 1; \
 	done
 
 .PHONY: static-linux
 static-linux: ## build static-compiled packages
-	$(MAKE) -C static VERSION=$(VERSION) APP_DIR=$(APP_DIR) GO_VERSION=$(GO_VERSION) static-linux
+	$(MAKE) -C static APP_DIR=$(APP_DIR) GO_VERSION=$(GO_VERSION) static-linux
 
 .PHONY: cross-mac
 cross-mac: ## build static-compiled packages
-	$(MAKE) -C static VERSION=$(VERSION) APP_DIR=$(APP_DIR) GO_VERSION=$(GO_VERSION) cross-mac
+	$(MAKE) -C static APP_DIR=$(APP_DIR) GO_VERSION=$(GO_VERSION) cross-mac
 
 .PHONY: cross-win
 cross-win: ## build static-compiled packages
-	$(MAKE) -C static VERSION=$(VERSION) APP_DIR=$(APP_DIR) GO_VERSION=$(GO_VERSION) cross-win
+	$(MAKE) -C static APP_DIR=$(APP_DIR) GO_VERSION=$(GO_VERSION) cross-win

--- a/packaging/deb/Makefile
+++ b/packaging/deb/Makefile
@@ -2,7 +2,6 @@ include ../common.mk
 
 APP_DIR:=$(realpath $(CURDIR)/../../)
 GITCOMMIT?=$(shell cd $(APP_DIR) && git rev-parse --short HEAD)
-STATIC_VERSION:=$(shell ../static/gen-static-ver $(APP_DIR) $(VERSION))
 GO_BASE_IMAGE=golang
 GO_IMAGE=$(GO_BASE_IMAGE):$(GO_VERSION)-stretch
 DEB_VERSION=$(shell ./gen-deb-ver $(APP_DIR) "$(VERSION)")

--- a/packaging/static/Makefile
+++ b/packaging/static/Makefile
@@ -1,7 +1,6 @@
 include ../common.mk
 
 APP_DIR:=$(realpath $(CURDIR)/../../)
-STATIC_VERSION:=$(shell ./gen-static-ver $(APP_DIR) $(VERSION))
 CGO_ENABLED ?= 0
 CHOWN=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 HASH_CMD=docker run -v $(CURDIR):/sum -w /sum debian:jessie bash hash_files
@@ -24,9 +23,9 @@ static: static-linux cross-mac cross-win cross-arm ## create all static packages
 .PHONY: static-linux
 static-linux:
 	mkdir -p build/linux/cri-dockerd
-	cd $(APP_DIR) && go get && env CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=amd64 go build -o cri-dockerd
+	cd $(APP_DIR) && go get && env CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=amd64 go build ${LDFLAGS} -o cri-dockerd
 	mv $(APP_DIR)/cri-dockerd build/linux/cri-dockerd/cri-dockerd
-	tar -C build/linux -c -z -f build/linux/cri-dockerd-$(STATIC_VERSION).tgz cri-dockerd
+	tar -C build/linux -c -z -f build/linux/cri-dockerd-$(VERSION).tgz cri-dockerd
 
 .PHONY: hash_files
 hash_files:
@@ -36,23 +35,23 @@ hash_files:
 .PHONY: cross-mac
 cross-mac:
 	mkdir -p build/mac/cri-dockerd
-	cd $(APP_DIR) && go get && env CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=amd64 go build -o cri-dockerd-darwin-amd64
+	cd $(APP_DIR) && go get && env CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=amd64 go build ${LDFLAGS} -o cri-dockerd-darwin-amd64
 	mv $(APP_DIR)/cri-dockerd-darwin-amd64 build/mac/cri-dockerd/cri-dockerd
-	tar -C build/mac -c -z -f build/mac/cri-dockerd-$(STATIC_VERSION).tgz cri-dockerd
+	tar -C build/mac -c -z -f build/mac/cri-dockerd-$(VERSION).tgz cri-dockerd
 
 .PHONY: cross-win
 cross-win:
 	mkdir -p build/win/cri-dockerd
-	cd $(APP_DIR) && go get && env CGO_ENABLED=$(CGO_ENABLED) GOOS=windows GOARCH=amd64 go build -o cri-dockerd-windows-amd64
+	cd $(APP_DIR) && go get && env CGO_ENABLED=$(CGO_ENABLED) GOOS=windows GOARCH=amd64 go build ${LDFLAGS} -o cri-dockerd-windows-amd64
 	mv $(APP_DIR)/cri-dockerd-windows-amd64 build/win/cri-dockerd/cri-dockerd.exe
 	if ! grep -sq 'docker\|lxc' /proc/1/cgroup; then \
-	    docker run --rm -v $(CURDIR)/build/win:/v -w /v alpine sh -c 'apk update && apk add zip && zip -r cri-dockerd-$(STATIC_VERSION).zip cri-dockerd'; \
+	    docker run --rm -v $(CURDIR)/build/win:/v -w /v alpine sh -c 'apk update && apk add zip && zip -r cri-dockerd-$(VERSION).zip cri-dockerd'; \
 	    $(CHOWN) -R $(shell id -u):$(shell id -g) build; \
 	fi
 
 .PHONY: cross-arm
 cross-arm: ## create tgz with linux armhf client only
 	mkdir -p build/arm/cri-dockerd
-	cd $(APP_DIR) && go get && env CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=arm64 go build -o cri-dockerd-arm64
+	cd $(APP_DIR) && go get && env CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=arm64 go build ${LDFLAGS} -o cri-dockerd-arm64
 	mv $(APP_DIR)/cri-dockerd-arm64 build/arm/cri-dockerd/cri-dockerd
-	tar -C build/arm -c -z -f build/arm/cri-dockerd-$(STATIC_VERSION).tgz cri-dockerd
+	tar -C build/arm -c -z -f build/arm/cri-dockerd-$(VERSION).tgz cri-dockerd

--- a/packaging/static/gen-static-ver
+++ b/packaging/static/gen-static-ver
@@ -15,7 +15,11 @@ fi
 GIT_COMMAND="git -C $APP_DIR"
 
 staticVersion="$VERSION"
-if [[ "$VERSION" == *-dev ]]; then
+
+gitTag=$($GIT_COMMAND describe --abbrev=0 --tags)
+if [[ $? -eq 0 ]]; then
+    staticVersion="${gitTag/v/}"
+else
     # based on golang's pseudo-version: https://groups.google.com/forum/#!topic/golang-dev/a5PqQuBljF4
     #
     # using a "pseudo-version" of the form v0.0.0-yyyymmddhhmmss-abcdefabcdef,


### PR DESCRIPTION
If a build is done from an untagged commit, include a short githash
in the build number, otherwise use the tag.

Substitute the values with `-ldflags` during the build so
`cri-dockerd --version` shows them appropriately instead of the
stubs.

Closes #19 