### PR TITLE
Fix a typo in the systemd/upstart scripts for cri-dockerd.sock

### DIFF
--- a/packaging/deb/common/cri-docker.docker.upstart
+++ b/packaging/deb/common/cri-docker.docker.upstart
@@ -14,9 +14,9 @@ script
 	exec "$CRI_DOCKERD" --container-runtime-endpoint fd:// --networkplugin=""
 end script
 
-# Don't emit "started" event until cri-docker.sock is ready.
+# Don't emit "started" event until cri-dockerd.sock is ready.
 post-start script
-	CRI_DOCKER_SOCKET=/var/run/cri-docker.sock
+	CRI_DOCKER_SOCKET=/var/run/cri-dockerd.sock
 
 	if [ -n "$CRI_DOCKER_SOCKET" ]; then
 		while ! [ -e "$CRI_DOCKER_SOCKET" ]; do

--- a/packaging/systemd/cri-docker.socket
+++ b/packaging/systemd/cri-docker.socket
@@ -3,7 +3,7 @@ Description=CRI Docker Socket for the API
 PartOf=cri-docker.service
 
 [Socket]
-ListenStream=%t/cri-docker.sock
+ListenStream=%t/cri-dockerd.sock
 SocketMode=0660
 SocketUser=root
 SocketGroup=docker


### PR DESCRIPTION
Replace cri-docker.sock with cri-dockerd.sock

Closes #24 