### PR TITLE
Parameterize more Makefile variables, add a --buildinfo flag

### DIFF
--- a/packaging/common.mk
+++ b/packaging/common.mk
@@ -1,9 +1,7 @@
 ARCH=$(shell uname -m)
-BUILDTIME=$(shell date -u -d "@$${SOURCE_DATE_EPOCH:-$$(date +%s)}" --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
 GO_VERSION:=1.16.8
 PLATFORM=cri-dockerd
 SHELL:=/bin/bash
 VERSION?=0.2.0-dev
 
-export BUILDTIME
 export PLATFORM

--- a/src/cmd/server.go
+++ b/src/cmd/server.go
@@ -85,6 +85,19 @@ func NewDockerCRICommand(stopCh <-chan struct{}) *cobra.Command {
 				return
 			}
 
+			infoflag, _ := cleanFlagSet.GetBool("buildinfo")
+			if infoflag {
+				fmt.Fprintf(
+					cmd.OutOrStderr(),
+					"Program: %s\nVersion: %s\nBuildTime: %s\nGitCommit: %s\n",
+					version.PlatformName,
+					version.FullVersion(),
+					version.BuildTime,
+					version.GitCommit,
+				)
+				return
+			}
+
 			logFlag, _ := cleanFlagSet.GetString("log-level")
 			if logFlag != "" {
 				level, err := logrus.ParseLevel(logFlag)
@@ -104,6 +117,7 @@ func NewDockerCRICommand(stopCh <-chan struct{}) *cobra.Command {
 	kubeletFlags.AddFlags(cleanFlagSet)
 	cleanFlagSet.BoolP("help", "h", false, fmt.Sprintf("Help for %s", cmd.Name()))
 	cleanFlagSet.Bool("version", false, "Prints the version of cri-dockerd")
+	cleanFlagSet.Bool("buildinfo", false, "Prints the build information about cri-dockerd")
 	cleanFlagSet.String("log-level", "info", "The log level for cri-docker")
 
 	// ugly, but necessary, because Cobra's default UsageFunc and HelpFunc pollute the flagset with global flags


### PR DESCRIPTION
Allow for REVISION|GIT_COMMIT, VERSION, and others to be set by
Makefile users who may have this project in a submodule or different
repo.

Closes #30 