### PR TITLE
Add image info to the verbose status command

### DIFF
--- a/src/core/image.go
+++ b/src/core/image.go
@@ -94,7 +94,15 @@ func (ds *dockerService) ImageStatus(
 
 	res := runtimeapi.ImageStatusResponse{Image: imageStatus}
 	if r.GetVerbose() {
-		res.Info = imageInspect.Config.Labels
+		imageHistory, err := ds.client.ImageHistory(imageInspect.ID)
+		if err != nil {
+			return nil, err
+		}
+		imageInfo, err := imageInspectToRuntimeAPIImageInfo(imageInspect, imageHistory)
+		if err != nil {
+			return nil, err
+		}
+		res.Info = imageInfo
 	}
 	return &res, nil
 }

--- a/src/go.mod
+++ b/src/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.8.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0
+	github.com/opencontainers/image-spec v1.0.1
 	github.com/opencontainers/runc v1.0.0-rc92
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1


### PR DESCRIPTION
Do a combination of the cri-o format (with "labels") and the
containerd format (without "chainID") for the info JSON field.

cri-o
```go
        struct {
                Labels    map[string]string `json:"labels,omitempty"`
                ImageSpec *specs.Image      `json:"imageSpec"`
        }
```

containerd
```go
struct {
        ChainID   string          `json:"chainID"`
        ImageSpec imagespec.Image `json:"imageSpec"`
}
```



The info is supposed to include the history, so make a special
call for that in verbose and reverse order to match containerd.