### PR TITLE
Update packaging targets

### DIFF
--- a/core/stats.go
+++ b/core/stats.go
@@ -61,8 +61,9 @@ func (ds *dockerService) ListContainerStats(
 	var wg sync.WaitGroup
 	var stats = make([]*runtimeapi.ContainerStats, 0, len(listResp.Containers))
 	for _, container := range listResp.Containers {
+		container := container
+		wg.Add(1)
 		go func() {
-			wg.Add(1)
 			defer wg.Done()
 			if containerStats, err := ds.getContainerStats(container.Id); err == nil && containerStats != nil {
 				mtx.Lock()

--- a/packaging/deb/Makefile
+++ b/packaging/deb/Makefile
@@ -37,7 +37,7 @@ SOURCES=$(addprefix sources/, $(SOURCE_FILES))
 
 DEBIAN_VERSIONS := debian-stretch debian-buster
 #UBUNTU_VERSIONS := ubuntu-xenial ubuntu-bionic ubuntu-cosmic ubuntu-disco ubuntu-eoan
-UBUNTU_VERSIONS := ubuntu-bionic
+UBUNTU_VERSIONS := ubuntu-bionic ubuntu-jammy
 RASPBIAN_VERSIONS := raspbian-stretch raspbian-buster
 DISTROS := $(DEBIAN_VERSIONS) $(UBUNTU_VERSIONS) $(RASPBIAN_VERSIONS)
 

--- a/packaging/deb/ubuntu-jammy/Dockerfile
+++ b/packaging/deb/ubuntu-jammy/Dockerfile
@@ -1,0 +1,33 @@
+ARG GO_IMAGE
+ARG DISTRO=ubuntu
+ARG SUITE=bionic
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+
+RUN apt-get update && apt-get install -y curl devscripts equivs git
+
+ENV GOPROXY=direct
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
+RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+
+COPY sources/ /sources
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+
+COPY --from=golang /usr/local/go /usr/local/go
+
+WORKDIR /root/build-deb
+COPY build-deb /root/build-deb/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]

--- a/packaging/rpm/Makefile
+++ b/packaging/rpm/Makefile
@@ -1,6 +1,6 @@
 include ../common.mk
 
-APP_DIR:=$(realpath $(CURDIR)/../../app)
+APP_DIR:=$(realpath $(CURDIR)/../../)
 STATIC_VERSION:=$(shell ../static/gen-static-ver $(APP_DIR) $(VERSION))
 GO_BASE_IMAGE=golang
 GO_IMAGE?=$(GO_BASE_IMAGE):$(GO_VERSION)-stretch
@@ -41,8 +41,8 @@ RUN?=$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 SOURCE_FILES=app.tgz cri-docker.service cri-docker.socket
 SOURCES=$(addprefix rpmbuild/SOURCES/, $(SOURCE_FILES))
 
-FEDORA_RELEASES := fedora-34
-CENTOS_RELEASES := centos-8 centos-7
+FEDORA_RELEASES := fedora-36 fedora-35
+CENTOS_RELEASES := centos-stream centos-7
 
 .PHONY: help
 help: ## show make targets

--- a/packaging/rpm/centos-stream/Dockerfile
+++ b/packaging/rpm/centos-stream/Dockerfile
@@ -1,0 +1,26 @@
+ARG GO_IMAGE
+ARG DISTRO=tgagor/centos
+ARG SUITE=stream8
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+ENV GOPROXY=direct
+ENV GOPATH=/go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS seccomp selinux
+ENV RUNC_BUILDTAGS seccomp selinux
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+RUN yum install -y rpm-build rpmlint yum-utils
+RUN dnf config-manager --set-enabled powertools
+COPY SPECS /root/rpmbuild/SPECS
+# Overwrite repo that was failing on aarch64
+RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec
+COPY --from=golang /usr/local/go /usr/local/go
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]

--- a/packaging/rpm/fedora-36/Dockerfile
+++ b/packaging/rpm/fedora-36/Dockerfile
@@ -1,0 +1,24 @@
+ARG GO_IMAGE
+ARG DISTRO=fedora
+ARG SUITE=36
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+ENV GOPROXY=direct
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS seccomp selinux
+ENV RUNC_BUILDTAGS seccomp selinux
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+RUN dnf install -y rpm-build rpmlint dnf-plugins-core
+COPY SPECS /root/rpmbuild/SPECS
+RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
+COPY --from=golang /usr/local/go /usr/local/go
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]

--- a/packaging/windows/Makefile
+++ b/packaging/windows/Makefile
@@ -1,6 +1,6 @@
 include ../common.mk
 
-APP_DIR:=$(realpath $(CURDIR)/../../app)
+APP_DIR:=$(realpath $(CURDIR)/../../)
 GO_BASE_IMAGE=golang
 WINDOWS_BUILDER?=windows-engine-builder
 GOPATH=C:\go


### PR DESCRIPTION
Include centos-stream instead of 8, remove Fedora 34, add Fedora 36, add Ubuntu Jammy.

Merge in additional stats changes from comments in a PR which never made it in.

Closes #38 