### PR TITLE
Fix not reporting memory usage

### DIFF
--- a/core/stats_linux.go
+++ b/core/stats_linux.go
@@ -69,7 +69,7 @@ func (ds *dockerService) getContainerStats(containerID string) (*runtimeapi.Cont
 		Memory: &runtimeapi.MemoryUsage{
 			Timestamp: timestamp,
 			WorkingSetBytes: &runtimeapi.UInt64Value{
-				Value: dockerStats.MemoryStats.PrivateWorkingSet,
+				Value: dockerStats.MemoryStats.Usage,
 			},
 		},
 		WritableLayer: &runtimeapi.FilesystemUsage{


### PR DESCRIPTION
When I was running `crictl stats` I wasn't getting any memory usage reported, everything was 0.
```
$ crictl stats
CONTAINER           CPU %               MEM                 DISK                INODES
151dfb4aa44a8       2.33                0B                  0B                  0
8396e703be70c       0.40                0B                  0B                  0
8d098a7107992       0.00                0B                  2.294kB             0
d1431067b2940       0.19                0B                  0B                  0
dbce1442651b2       6.69                0B                  0B                  0
f4c66fafc1f19       0.43                0B                  0B                  0
f8e33de11bb58       0.30                0B                  0B                  0
fe27b6c89bdb6       3.57                0B                  0B                  0
```

I checked the response of:
https://github.com/Mirantis/cri-dockerd/blob/5d7c9ba59e92405df86bff0eb3a2a9fefdafed50/libdocker/kube_docker_client.go#L612

And it was:
```
{
   ...
   "memory_stats":{
      "usage":14479360,
      "stats":{...},
      "limit":6232580096
   },
   ...
}
```

There is no `PrivateWorkingSet` field being returned from Docker, changing it to `Usage` resulted in the following:
```
CONTAINER           CPU %               MEM                 DISK                INODES
219a899e5607d       0.31                11.55MB             0B                  0
24b4c111d2f5a       0.40                15.67MB             0B                  0
282e95aafc4b6       0.54                13.65MB             0B                  0
6751f1fd2b742       0.01                10.96MB             2.294kB             0
675fb173de807       2.75                43.97MB             0B                  0
8a3fa3d62f6e6       0.26                7.995MB             0B                  0
edc7e0037532c       7.35                345MB               0B                  0
ffadb0bd1808d       2.27                29.68MB             0B                  0
```