### PR TITLE
Make HairpinMode configurable

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/Mirantis/cri-dockerd/backend"
 	"github.com/Mirantis/cri-dockerd/cmd/cri/options"
 	"github.com/Mirantis/cri-dockerd/cmd/version"
@@ -151,7 +152,7 @@ func RunCriDockerd(f *options.DockerCRIFlags, stopCh <-chan struct{}) error {
 
 	// Initialize network plugin settings.
 	pluginSettings := config.NetworkPluginSettings{
-		HairpinMode:        "none",
+		HairpinMode:        config.HairpinModeVar.Mode(),
 		PluginName:         f.NetworkPluginName,
 		PluginConfDir:      f.CNIConfDir,
 		PluginBinDirString: f.CNIBinDir,

--- a/config/constants.go
+++ b/config/constants.go
@@ -19,9 +19,6 @@ package config
 // Protocol is the type of port mapping protocol
 type Protocol string
 
-// HairpinMode is the type of network hairpin modes
-type HairpinMode string
-
 // UID represents a UID
 type UID string
 
@@ -38,12 +35,9 @@ const (
 
 // Networking contstants
 const (
-	PromiscuousBridge HairpinMode = "promiscuous-bridge"
-	HairpinVeth       HairpinMode = "hairpin-veth"
-	HairpinNone       HairpinMode = "none"
-	ProtocolTCP       Protocol    = "TCP"
-	ProtocolUDP       Protocol    = "UDP"
-	ProtocolSCTP      Protocol    = "SCTP"
+	ProtocolTCP  Protocol = "TCP"
+	ProtocolUDP  Protocol = "UDP"
+	ProtocolSCTP Protocol = "SCTP"
 )
 
 // Container logging constants

--- a/config/hairpin.go
+++ b/config/hairpin.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2022 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+)
+
+// HairpinMode is the type of network hairpin modes
+type HairpinMode string
+
+// HairpinModeValue implements pflag's Value interface
+type HairpinModeValue struct {
+	value string
+}
+
+// HairpinModeVar contains the value of the hairpin-mode flag
+var HairpinModeVar HairpinModeValue
+
+const (
+	PromiscuousBridge HairpinMode = "promiscuous-bridge"
+	HairpinVeth       HairpinMode = "hairpin-veth"
+	HairpinNone       HairpinMode = "none"
+)
+
+var validHairpinModes = []HairpinMode{PromiscuousBridge, HairpinVeth, HairpinNone}
+
+func (h *HairpinModeValue) String() string {
+	if h.value == "" {
+		return string(HairpinNone)
+	}
+	return h.value
+}
+
+func (h *HairpinModeValue) Set(mode string) error {
+	for _, v := range validHairpinModes {
+		if string(v) != mode {
+			continue
+		}
+		h.value = mode
+		return nil
+	}
+	return fmt.Errorf("%q is not a valid hairpin-mode value, must be one of: %+q", mode, validHairpinModes)
+}
+
+func (h *HairpinModeValue) Type() string {
+	return "HairpinMode"
+}
+
+func (h *HairpinModeValue) Mode() HairpinMode {
+	return HairpinMode(h.String())
+}

--- a/config/options.go
+++ b/config/options.go
@@ -74,6 +74,9 @@ type ContainerRuntimeOptions struct {
 	// CNICacheDir is the full path of the directory in which CNI should store
 	// cache files
 	CNICacheDir string
+	// HairpinMode is the mode used to allow endpoints of a Service to load
+	// balance back to themselves if they should try to access their own Service
+	HairpinMode HairpinMode
 }
 
 // AddFlags has the set of flags needed by cri-dockerd
@@ -159,6 +162,13 @@ func (s *ContainerRuntimeOptions) AddFlags(fs *pflag.FlagSet) {
 		s.NetworkPluginMTU,
 		fmt.Sprintf(
 			"<Warning: Alpha feature> The MTU to be passed to the network plugin, to override the default. Set to 0 to use the default 1460 MTU.",
+		),
+	)
+	fs.Var(
+		&HairpinModeVar,
+		"hairpin-mode",
+		fmt.Sprintf(
+			"<Warning: Alpha feature> The mode of hairpin to use.",
 		),
 	)
 }


### PR DESCRIPTION
`HairpinMode` was hardcoded to `none`, resulting in some CNIs failing to hairpin.

Added a `hairpin-mode` flag that allows the user to choose between the three valid options. The default stays as `none`.

Error when invalid value passed:
`"test123" is not a valid hairpin-mode value, must be one of: ["promiscuous-bridge", "hairpin-veth", "none"]`

