### PR TITLE
fix debian packages

### DIFF
--- a/packaging/common.mk
+++ b/packaging/common.mk
@@ -1,7 +1,7 @@
 ARCH=$(shell uname -m)
-GO_VERSION:=1.18.2
+GO_VERSION:=1.18.3
 PLATFORM=cri-dockerd
 SHELL:=/bin/bash
-VERSION?=0.2.1-dev
+VERSION?=0.2.2-dev
 
 export PLATFORM

--- a/packaging/deb/Makefile
+++ b/packaging/deb/Makefile
@@ -38,7 +38,7 @@ SOURCES=$(addprefix sources/, $(SOURCE_FILES))
 DEBIAN_VERSIONS := debian-stretch debian-buster debian-bullseye
 #UBUNTU_VERSIONS := ubuntu-xenial ubuntu-bionic ubuntu-cosmic ubuntu-disco ubuntu-eoan
 UBUNTU_VERSIONS := ubuntu-bionic ubuntu-focal ubuntu-jammy
-RASPBIAN_VERSIONS := raspbian-stretch raspbian-buster
+RASPBIAN_VERSIONS := raspbian-stretch raspbian-buster raspbian-bullseye
 DISTROS := $(DEBIAN_VERSIONS) $(UBUNTU_VERSIONS) $(RASPBIAN_VERSIONS)
 
 .PHONY: help

--- a/packaging/deb/Makefile
+++ b/packaging/deb/Makefile
@@ -35,7 +35,7 @@ RUN=docker run --rm -i \
 SOURCE_FILES=app.tgz cri-docker.service cri-docker.socket
 SOURCES=$(addprefix sources/, $(SOURCE_FILES))
 
-DEBIAN_VERSIONS := debian-stretch debian-buster
+DEBIAN_VERSIONS := debian-stretch debian-buster debian-bullseye
 #UBUNTU_VERSIONS := ubuntu-xenial ubuntu-bionic ubuntu-cosmic ubuntu-disco ubuntu-eoan
 UBUNTU_VERSIONS := ubuntu-bionic ubuntu-focal ubuntu-jammy
 RASPBIAN_VERSIONS := raspbian-stretch raspbian-buster

--- a/packaging/deb/common/control
+++ b/packaging/deb/common/control
@@ -26,7 +26,10 @@ Vcs-Git: git://github.com/Mirantis/cri-dockerd.git
 
 Package: cri-dockerd
 Architecture: linux-any
-Depends: containerd.io (>= 1.2.2-3), iptables, libseccomp2 (>= 2.3.0), ${shlibs:Depends}
+Depends: containerd (>= 1.2.2-3) | containerd.io (>= 1.2.2-3),
+         iptables,
+         libseccomp2 (>= 2.3.0),
+         ${shlibs:Depends}
 Recommends: aufs-tools [amd64],
             ca-certificates,
             cgroupfs-mount | cgroup-lite,

--- a/packaging/deb/debian-bullseye/Dockerfile
+++ b/packaging/deb/debian-bullseye/Dockerfile
@@ -1,0 +1,34 @@
+ARG GO_IMAGE
+ARG DISTRO=debian
+ARG SUITE=bullseye
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y curl devscripts equivs git
+
+ENV GOPROXY=direct
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
+RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+
+COPY sources/ /sources
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+
+COPY --from=golang /usr/local/go /usr/local/go
+
+WORKDIR /root/build-deb
+COPY build-deb /root/build-deb/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]

--- a/packaging/deb/raspbian-bullseye/Dockerfile
+++ b/packaging/deb/raspbian-bullseye/Dockerfile
@@ -1,0 +1,33 @@
+ARG GO_IMAGE
+ARG DISTRO=raspbian
+ARG SUITE=bullseye
+ARG BUILD_IMAGE=balenalib/rpi-raspbian:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+
+RUN apt-get update && apt-get install -y curl devscripts equivs git
+
+ENV GOPROXY=direct
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
+RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+
+COPY sources/ /sources
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+
+COPY --from=golang /usr/local/go /usr/local/go
+
+WORKDIR /root/build-deb
+COPY build-deb /root/build-deb/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]


### PR DESCRIPTION
- correct debian dependencies, packaging version
  - fixes #80
  - temporarily bodges #81
- add debian bullseye to packages
- add raspbian bullseye too

The fix to #81 is very temporary, as the version is still hard coded instead
of being driven by some release automation reading tags or the like. So
unless someone updates it again, the next release will still be wrong :)
