### PR TITLE
Remove error logging output from ContainerStats

### DIFF
--- a/libdocker/kube_docker_client.go
+++ b/libdocker/kube_docker_client.go
@@ -610,7 +610,6 @@ func (d *kubeDockerClient) GetContainerStats(id string) (*dockertypes.StatsJSON,
 	defer cancel()
 
 	response, err := d.client.ContainerStats(ctx, id, false)
-	logrus.Error("ContainerStats resp: ", response)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Accidentally included in f00eefee421e532a9bf7b8c348ad37fc0be48211

It should probably at least have used "Debug", and not "Error"...

Closes #85

* #85