### PR TITLE
Return the right error code when the checkpoint isn't found

### DIFF
--- a/store/checkpointmanager.go
+++ b/store/checkpointmanager.go
@@ -81,6 +81,9 @@ func (manager *checkPointImpl) GetCheckpoint(checkpointKey string, checkpoint Ch
 	defer manager.mutex.Unlock()
 	blob, err := manager.store.Read(checkpointKey)
 	if err != nil {
+		if err == ErrKeyNotFound {
+			return ErrCheckpointNotFound
+		}
 		return err
 	}
 	err = checkpoint.UnmarshalCheckpoint(blob)


### PR DESCRIPTION
There's a few places that check for this specific error that are currently never being hit: https://github.com/Mirantis/cri-dockerd/blob/780679eaad46c1e6bc0e9cc61780bbf7f616c8b6/core/sandbox_port_forward.go#L123-L125 .

Likely fixes #52