### PR TITLE
Switch from k8s.gcr.io to registry.k8s.io for sandbox image

### DIFF
--- a/cmd/cri/options/options.go
+++ b/cmd/cri/options/options.go
@@ -90,7 +90,7 @@ func (f *DockerCRIFlags) AddFlags(mainfs *pflag.FlagSet) {
 }
 
 const (
-	defaultPodSandboxImageName    = "k8s.gcr.io/pause"
+	defaultPodSandboxImageName    = "registry.k8s.io/pause"
 	defaultPodSandboxImageVersion = "3.6"
 )
 

--- a/core/sandbox_helpers.go
+++ b/core/sandbox_helpers.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	defaultSandboxImage = "k8s.gcr.io/pause:3.6"
+	defaultSandboxImage = "registry.k8s.io/pause:3.6"
 
 	// Various default sandbox resources requests/limits.
 	defaultSandboxCPUshares int64 = 2


### PR DESCRIPTION
As per https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io) 

`The older "k8s.gcr.io" will continue to be available for a while to help transition and avoid breaking folks, so please don't panic :) However, please do start switching to the new registry.k8s.io wherever you can, and definitely for k8s 1.25, that will be the default.`

Details:
https://github.com/kubernetes/kubernetes/pull/109938
https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)
https://groups.google.com/g/kubernetes-sig-testing/c/U7b_im9vRrM/m/7qywJeUTBQAJ?pli=1