### PR TITLE
Add container info to the verbose status command

### DIFF
--- a/core/container_status.go
+++ b/core/container_status.go
@@ -136,6 +136,14 @@ func (ds *dockerService) ContainerStatus(
 		Annotations: annotations,
 		LogPath:     r.Config.Labels[containerLogPathLabelKey],
 	}
-	return &v1.ContainerStatusResponse{Status: status}, nil
+	res := v1.ContainerStatusResponse{Status: status}
+	if req.GetVerbose() {
+		containerInfo, err := containerInspectToRuntimeAPIContainerInfo(r)
+		if err != nil {
+			return nil, err
+		}
+		res.Info = containerInfo
+	}
+	return &res, nil
 }
 

--- a/core/convert.go
+++ b/core/convert.go
@@ -110,6 +110,29 @@ func imageInspectToRuntimeAPIImageInfo(image *dockertypes.ImageInspect, history 
 	return info, nil
 }
 
+type verboseContainerInfo struct {
+	SandboxID string `json:"sandboxID"`
+	Pid       int    `json:"pid"`
+}
+
+func containerInspectToRuntimeAPIContainerInfo(container *dockertypes.ContainerJSON) (map[string]string, error) {
+	info := make(map[string]string)
+
+	cti := &verboseContainerInfo{
+		SandboxID: container.Config.Labels[sandboxIDLabelKey],
+		Pid:       container.State.Pid,
+	}
+
+	m, err := json.Marshal(cti)
+	if err == nil {
+		info["info"] = string(m)
+	} else {
+		return nil, err
+	}
+
+	return info, nil
+}
+
 func toRuntimeAPIConfig(config *dockercontainer.Config) imagespec.ImageConfig {
 	ports := make(map[string]struct{})
 	for k, v := range config.ExposedPorts {


### PR DESCRIPTION
Include the basic information from cri-o and containerd, that is
the SandboxID (the pause container id) and the Pid (process id).