### PR TITLE
make the build reproducible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,10 @@ endif
 export VERSION?=$(shell (git describe --abbrev=0 --tags | sed -e 's/v//') || echo $(cat VERSION)-$(git log -1 --pretty='%h'))
 PRERELEASE=`grep -q dev <<< "${VERSION}" && echo "pre" || echo ""`
 REVISION?=`git log -1 --pretty='%h'`
-export CRI_DOCKERD_LDFLAGS=-ldflags "-X github.com/Mirantis/cri-dockerd/cmd/version.Version=${VERSION} -X github.com/Mirantis/cri-dockerd/cmd/version.PreRelease=${PRERELEASE} -X github.com/Mirantis/cri-dockerd/cmd/version.BuildTime=${BUILD_DATE} -X github.com/Mirantis/cri-dockerd/cmd/version.GitCommit=${REVISION}"
+export CRI_DOCKERD_LDFLAGS=-ldflags "-s -w -buildid=${REVISION} \
+	-X github.com/Mirantis/cri-dockerd/cmd/version.Version=${VERSION} \
+	-X github.com/Mirantis/cri-dockerd/cmd/version.PreRelease=${PRERELEASE} \
+	-X github.com/Mirantis/cri-dockerd/cmd/version.GitCommit=${REVISION}"
 
 .PHONY: help
 help: ## show make targets

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/Mirantis/cri-dockerd/backend"
 	"github.com/Mirantis/cri-dockerd/cmd/cri/options"
@@ -92,11 +93,11 @@ func NewDockerCRICommand(stopCh <-chan struct{}) *cobra.Command {
 			if infoflag {
 				fmt.Fprintf(
 					cmd.OutOrStderr(),
-					"Program: %s\nVersion: %s\nBuildTime: %s\nGitCommit: %s\n",
+					"Program: %s\nVersion: %s\nGitCommit: %s\nGo version: %s\n",
 					version.PlatformName,
 					version.FullVersion(),
-					version.BuildTime,
 					version.GitCommit,
+					runtime.Version(),
 				)
 				return
 			}

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -7,8 +7,6 @@ var (
 	PreRelease = ""
 	// GitCommit is set during the build
 	GitCommit = "HEAD"
-	// BuildTime is set during the build
-	BuildTime = "<unknown>"
 )
 
 const (

--- a/packaging/static/Makefile
+++ b/packaging/static/Makefile
@@ -49,7 +49,7 @@ static: static-linux cross-mac cross-win cross-arm ## create all static packages
 .PHONY: static-linux
 static-linux:
 	mkdir -p build/linux/cri-dockerd
-	cd $(APP_DIR) && env CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(ARCH) go build ${CRI_DOCKERD_LDFLAGS} -o cri-dockerd
+	cd $(APP_DIR) && env CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(ARCH) go build -trimpath ${CRI_DOCKERD_LDFLAGS} -o cri-dockerd
 	mv $(APP_DIR)/cri-dockerd build/linux/cri-dockerd/cri-dockerd
 	tar -C build/linux -c -z -f build/linux/cri-dockerd-$(VERSION).tgz cri-dockerd
 
@@ -61,14 +61,14 @@ hash_files:
 .PHONY: cross-mac
 cross-mac:
 	mkdir -p build/mac/cri-dockerd
-	cd $(APP_DIR) && env CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=$(ARCH) go build ${CRI_DOCKERD_LDFLAGS} -o cri-dockerd-darwin-amd64
+	cd $(APP_DIR) && env CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=$(ARCH) go build -trimpath ${CRI_DOCKERD_LDFLAGS} -o cri-dockerd-darwin-amd64
 	mv $(APP_DIR)/cri-dockerd-darwin-amd64 build/mac/cri-dockerd/cri-dockerd
 	tar -C build/mac -c -z -f build/mac/cri-dockerd-$(VERSION).tgz cri-dockerd
 
 .PHONY: cross-win
 cross-win:
 	mkdir -p build/win/cri-dockerd
-	cd $(APP_DIR) && env CGO_ENABLED=$(CGO_ENABLED) GOOS=windows GOARCH=$(ARCH) go build ${CRI_DOCKERD_LDFLAGS} -o cri-dockerd-windows-amd64
+	cd $(APP_DIR) && env CGO_ENABLED=$(CGO_ENABLED) GOOS=windows GOARCH=$(ARCH) go build -trimpath ${CRI_DOCKERD_LDFLAGS} -o cri-dockerd-windows-amd64
 	mv $(APP_DIR)/cri-dockerd-windows-amd64 build/win/cri-dockerd/cri-dockerd.exe
 	if ! grep -sq 'docker\|lxc' /proc/1/cgroup; then \
 	    docker run --rm -v $(CURDIR)/build/win:/v -w /v alpine sh -c 'apk update && apk add zip && zip -r cri-dockerd-$(VERSION).zip cri-dockerd'; \
@@ -78,6 +78,6 @@ cross-win:
 .PHONY: cross-arm
 cross-arm: ## create tgz with linux arm64 client only
 	mkdir -p build/arm/cri-dockerd
-	cd $(APP_DIR) && env CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=arm64 go build ${CRI_DOCKERD_LDFLAGS} -o cri-dockerd-arm64
+	cd $(APP_DIR) && env CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=arm64 go build -trimpath ${CRI_DOCKERD_LDFLAGS} -o cri-dockerd-arm64
 	mv $(APP_DIR)/cri-dockerd-arm64 build/arm/cri-dockerd/cri-dockerd
 	tar -C build/arm -c -z -f build/arm/cri-dockerd-$(VERSION).tgz cri-dockerd


### PR DESCRIPTION
This change makes the binaries easy to reproduce. This means that it is possible to produce the same binary given the same version of Go and the same git commit.

This change enables the verification of released binaries.

The following changes had to be made in order to do this:
- the build time had to be dropped
- the buildid had to be set via the ldflags
- trimpath had to be added to strip the GOPATH prefix from the source file paths, thus not including a path specific to the host where the binary was built
- the buildinfo output was modified to add the Go version & to remove the build time

These changes help produce binaries which have the exact same hash for the same version of Go.