### PR TITLE
Use the new make terget to install to the right paths

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,7 +75,7 @@ jobs:
         working-directory: src/sigs.k8s.io/cri-tools
         run: |
           make critest crictl
-          make install
+          find $(pwd)/build/bin -type f -exec mv {} /usr/local/bin \;
 
       - name: Checkout cri-dockerd
         uses: actions/checkout@v2


### PR DESCRIPTION
Build paths for `cri-tools` have moved into OS/arch based subdirs. Use the `install` Make target instead of manually copying now that it exists.