### PR TITLE
Move conntrack.Exists function into cri-dockerd

### DIFF
--- a/network/hostport/hostport_manager.go
+++ b/network/hostport/hostport_manager.go
@@ -67,12 +67,14 @@ func NewHostportManager(iptables utiliptables.Interface) HostPortManager {
 		iptables:    iptables,
 		portOpener:  openLocalPort,
 	}
-	h.conntrackFound = conntrack.Exists(h.execer)
-	if !h.conntrackFound {
+
+	_, err := h.execer.LookPath("conntrack")
+	if err != nil {
 		logrus.Info(
 			"The binary conntrack is not installed, this can cause failures in network connection cleanup.",
 		)
 	}
+
 	return h
 }
 


### PR DESCRIPTION
Move conntrack.Exists function to the cri-dockerd, because it has been deleted in the k8s project