### PR TITLE
Revert "check if running container also has ip address to return ready state"

### DIFF
--- a/core/sandbox_status.go
+++ b/core/sandbox_status.go
@@ -19,7 +19,6 @@ package core
 import (
 	"context"
 	"fmt"
-
 	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -42,6 +41,12 @@ func (ds *dockerService) PodSandboxStatus(
 	}
 	ct := createdAt.UnixNano()
 
+	// Translate container to sandbox state.
+	state := v1.PodSandboxState_SANDBOX_NOTREADY
+	if r.State.Running {
+		state = v1.PodSandboxState_SANDBOX_READY
+	}
+
 	var ips []string
 	// This is a workaround for windows, where sandbox is not in use, and pod IP is determined through containers belonging to the Pod.
 	if ips = ds.determinePodIPBySandboxID(podSandboxID); len(ips) == 0 {
@@ -54,13 +59,6 @@ func (ds *dockerService) PodSandboxStatus(
 	if len(ips) != 0 {
 		ip = ips[0]
 		ips = ips[1:]
-	}
-
-	// Translate container to sandbox state.
-	// For a sandbox to be in the Ready state, the container needs to be in the Running state and it also needs to have an IP address.
-	state := v1.PodSandboxState_SANDBOX_NOTREADY
-	if r.State.Running && len(ips) > 0 {
-		state = v1.PodSandboxState_SANDBOX_READY
 	}
 
 	labels, annotations := extractLabels(r.Config.Labels)


### PR DESCRIPTION
Revert this so bringup does not hang forever if no IPAM is available yet.