### PR TITLE
Various fixes to make the tests compile

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -173,7 +173,7 @@ func RunCriDockerd(f *options.DockerCRIFlags, stopCh <-chan struct{}) error {
 		if err != nil {
 			addr, err := netip.ParseAddr(r.StreamingBindAddr)
 			if err != nil {
-				logrus.Fatalf("Could not parse the given streaming bind address: %s", r.StreamingBindAddr, err)
+				logrus.Fatalf("Could not parse the given streaming bind address: %s", r.StreamingBindAddr)
 			}
 			resolvedAddr = net.JoinHostPort(addr.String(), "0")
 		} else {

--- a/core/helpers_test.go
+++ b/core/helpers_test.go
@@ -336,7 +336,7 @@ func TestGenerateMountBindings(t *testing.T) {
 		"/mnt/7:/var/lib/mysql/7",
 		"/mnt/8:/var/lib/mysql/8:ro,Z,rshared",
 	}
-	result := libdocker.GenerateMountBindings(mounts)
+	result := libdocker.GenerateMountBindings(mounts, "")
 
 	assert.Equal(t, expectedResult, result)
 }

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/container/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/container/helpers.go
@@ -39,7 +39,7 @@ import (
 
 // HandlerRunner runs a lifecycle handler for a container.
 type HandlerRunner interface {
-	Run(containerID ContainerID, pod *v1.Pod, container *v1.Container, handler *v1.Handler) (string, error)
+	Run(containerID ContainerID, pod *v1.Pod, container *v1.Container, handler *v1.LifecycleHandler) (string, error)
 }
 
 // RuntimeHelper wraps kubelet to make container runtime


### PR DESCRIPTION
I was trying to add a unit test, but the tests didn't even compile...

`cmd/server.go:176:5: github.com/sirupsen/logrus.Fatalf call needs 1 arg but has 2 args`

`core/helpers_test.go:339:44: not enough arguments in call to libdocker.GenerateMountBindings`

`vendor/k8s.io/kubernetes/pkg/kubelet/container/helpers.go:42:81: undefined: v1.Handler`