### PR TITLE
Fix container not found error

### DIFF
--- a/core/container_list.go
+++ b/core/container_list.go
@@ -18,6 +18,8 @@ package core
 
 import (
 	"context"
+
+	"github.com/Mirantis/cri-dockerd/libdocker"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/sirupsen/logrus"
@@ -55,7 +57,7 @@ func (ds *dockerService) ListContainers(
 		}
 	}
 	containers, err := ds.client.ListContainers(opts)
-	if err != nil {
+	if err != nil && (!libdocker.IsContainerNotFoundError(err)) {
 		return nil, err
 	}
 	// Convert docker to runtime api containers.

--- a/core/sandbox_list.go
+++ b/core/sandbox_list.go
@@ -18,6 +18,8 @@ package core
 
 import (
 	"context"
+
+	"github.com/Mirantis/cri-dockerd/libdocker"
 	"github.com/Mirantis/cri-dockerd/store"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -78,7 +80,7 @@ func (ds *dockerService) ListPodSandbox(
 	}
 
 	containers, err := ds.client.ListContainers(opts)
-	if err != nil {
+	if err != nil && (!libdocker.IsContainerNotFoundError(err)) {
 		return nil, err
 	}
 


### PR DESCRIPTION
We found that lots of exited `pause` containers were left on the node. 
According to this issue https://github.com/kubernetes/kubernetes/issues/110181, the docker's error type is different from the `crierror` definition which may cause this problem.
This PR tries to fix this.