### PR TITLE
Update the installation instructions in the README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ else
     BUILD_DATE?=$(shell date "$(DATE_FMT)")
 endif
 
+SHELL=/bin/bash
+
 export VERSION?=$(shell (git describe --abbrev=0 --tags | sed -e 's/v//') || echo $(cat VERSION)-$(git log -1 --pretty='%h'))
 PRERELEASE=`grep -q dev <<< "${VERSION}" && echo "pre" || echo ""`
 REVISION?=`git log -1 --pretty='%h'`
@@ -20,6 +22,10 @@ export CRI_DOCKERD_LDFLAGS=-ldflags "-s -w -buildid=${REVISION} \
 .PHONY: help
 help: ## show make targets
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf " \033[36m%-20s\033[0m  %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+.PHONY: cri-dockerd
+cri-dockerd: ## build cri-dockerd
+	GOARCH=$(ARCH) go build -trimpath $(CRI_DOCKERD_LDFLAGS) -o $@
 
 .PHONY: deb
 deb: ## build deb packages
@@ -52,4 +58,5 @@ cross-arm: ## build static packages
 
 .PHONY: clean
 clean: ## clean the build artifacts
+	$(RM) cri-dockerd
 	-$(MAKE) -C $(PACKAGING_DIR) clean

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ mkdir bin
 go build -o bin/cri-dockerd
 mkdir -p /usr/local/bin
 install -o root -g root -m 0755 bin/cri-dockerd /usr/local/bin/cri-dockerd
-cp -a packaging/systemd/* /etc/systemd/system
+install packaging/systemd/* /etc/systemd/system
 sed -i -e 's,/usr/bin/cri-dockerd,/usr/local/bin/cri-dockerd,' /etc/systemd/system/cri-docker.service
 systemctl daemon-reload
 systemctl enable cri-docker.service

--- a/README.md
+++ b/README.md
@@ -33,14 +33,6 @@ and on the Mirantis
 
 To begin following the build process for this code, clone this repository in your local environment:
 
-## To use with Kubernetes
-
-The default network plugin for `cri-dockerd` is set to `cni` on Linux. To change this, `--network-plugin=${plugin}`
-can be passed in as a command line argument if invoked manually, or the systemd unit file
-(`/usr/lib/systemd/system/cri-docker.service` if not enabled yet,
-or `/etc/systemd/system/multi-user.target.wants/cri-docker.service` as a symlink if it is enabled) should be
-edited to add this argument, followed by `systemctl daemon-reload` and restarting the service (if running)
-
 ```shell
 git clone https://github.com/Mirantis/cri-dockerd.git
 ```
@@ -48,6 +40,14 @@ git clone https://github.com/Mirantis/cri-dockerd.git
 The above step creates a local directory called ```cri-dockerd``` which you will need for the following steps.
 
 To build this code (in a POSIX environment):
+
+```shell
+###Install GO###
+wget https://storage.googleapis.com/golang/getgo/installer_linux
+chmod +x ./installer_linux
+./installer_linux
+source ~/.bash_profile
+```
 
 ```shell
 cd cri-dockerd
@@ -62,11 +62,6 @@ To install, on a Linux system that uses systemd, and already has Docker Engine i
 
 ```shell
 # Run these commands as root
-###Install GO###
-wget https://storage.googleapis.com/golang/getgo/installer_linux
-chmod +x ./installer_linux
-./installer_linux
-source ~/.bash_profile
 
 cd cri-dockerd
 mkdir bin
@@ -79,3 +74,11 @@ systemctl daemon-reload
 systemctl enable cri-docker.service
 systemctl enable --now cri-docker.socket
 ```
+
+## To use with Kubernetes
+
+The default network plugin for `cri-dockerd` is set to `cni` on Linux. To change this, `--network-plugin=${plugin}`
+can be passed in as a command line argument if invoked manually, or the systemd unit file
+(`/usr/lib/systemd/system/cri-docker.service` if not enabled yet,
+or `/etc/systemd/system/multi-user.target.wants/cri-docker.service` as a symlink if it is enabled) should be
+edited to add this argument, followed by `systemctl daemon-reload` and restarting the service (if running)

--- a/README.md
+++ b/README.md
@@ -41,13 +41,7 @@ The above step creates a local directory called ```cri-dockerd``` which you will
 
 To build this code (in a POSIX environment):
 
-```shell
-###Install GO###
-wget https://storage.googleapis.com/golang/getgo/installer_linux
-chmod +x ./installer_linux
-./installer_linux
-source ~/.bash_profile
-```
+<https://go.dev/doc/install>
 
 ```shell
 cd cri-dockerd

--- a/README.md
+++ b/README.md
@@ -58,16 +58,22 @@ go build -ldflags="-X github.com/Mirantis/cri-dockerd/version.Version='$VERSION}
 
 To build for a specific architecture, add `ARCH=` as an argument, where `ARCH` is a known build target for golang
 
+You can find pre-compiled binaries and deb/rpm packages under:
+
+<https://github.com/Mirantis/cri-dockerd/releases>
+
+Where `VERSION` is the latest available cri-dockerd version:
+
+`https://github.com/Mirantis/cri-dockerd/releases/download/v${VERSION}/cri-dockerd-${VERSION}.${ARCH}.tgz`
+
 To install, on a Linux system that uses systemd, and already has Docker Engine installed
 
 ```shell
 # Run these commands as root
 
 cd cri-dockerd
-mkdir bin
-go build -o bin/cri-dockerd
 mkdir -p /usr/local/bin
-install -o root -g root -m 0755 bin/cri-dockerd /usr/local/bin/cri-dockerd
+install -o root -g root -m 0755 cri-dockerd /usr/local/bin/cri-dockerd
 install packaging/systemd/* /etc/systemd/system
 sed -i -e 's,/usr/bin/cri-dockerd,/usr/local/bin/cri-dockerd,' /etc/systemd/system/cri-docker.service
 systemctl daemon-reload

--- a/README.md
+++ b/README.md
@@ -51,9 +51,7 @@ source ~/.bash_profile
 
 ```shell
 cd cri-dockerd
-mkdir bin
-VERSION=$((git describe --abbrev=0 --tags | sed -e 's/v//') || echo $(cat VERSION)-$(git log -1 --pretty='%h')) PRERELEASE=$(grep -q dev <<< "${VERSION}" && echo "pre" || echo "") REVISION=$(git log -1 --pretty='%h')
-go build -ldflags="-X github.com/Mirantis/cri-dockerd/version.Version='$VERSION}' -X github.com/Mirantis/cri-dockerd/version.PreRelease='$PRERELEASE' -X github.com/Mirantis/cri-dockerd/version.BuildTime='$BUILD_DATE' -X github.com/Mirantis/cri-dockerd/version.GitCommit='$REVISION'" -o cri-dockerd
+make cri-dockerd
 ```
 
 To build for a specific architecture, add `ARCH=` as an argument, where `ARCH` is a known build target for golang


### PR DESCRIPTION
* Move documentation sections to right place
* Use `install` instead of `cp -a` for selinux
* Prefer using binaries and don't rebuild
* Add make targets for build and install

Issue:
* #154

----

Don't duplicate all the strange go flags in the README, and don't rebuild the binary again during install.

Syntax had to be modified slightly in the Makefile, since it normally runs with `SHELL=/bin/sh` (not bash)

Mention that there are packages, although they might not exist for all distributions and all architectures.

Systemd units should normally be installed to the prefix location, only overrides and custom config in /etc
