### PR TITLE
Temporarily pin the cri-tools and kubernetes versions in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -92,6 +92,7 @@ jobs:
         with:
           repository: kubernetes/kubernetes
           path: src/k8s.io/kubernetes
+          ref: 84c8abfb8bf900ce36f7ebfbc52794bad972d8cc
 
       - name: Checkout test-infra for kubetest
         uses: actions/checkout@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -70,6 +70,7 @@ jobs:
         with:
           repository: kubernetes-sigs/cri-tools
           path: src/sigs.k8s.io/cri-tools
+          ref: e3c99451faee42de2fcf4568bdd81be8bb29e40f
 
       - name: Build cri-tools
         working-directory: src/sigs.k8s.io/cri-tools


### PR DESCRIPTION
Pin a specific commit for `cri-tools` and `kubernetes/kubernetes` to make e2e and integration tests pass until a permanent fix is made