### PR TITLE
Cache docker info and version

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -144,6 +144,7 @@ func NewDockerCRICommand(stopCh <-chan struct{}) *cobra.Command {
 
 // RunCriDockerd starts cri-dockerd
 func RunCriDockerd(f *options.DockerCRIFlags, stopCh <-chan struct{}) error {
+	logrus.Infof("Starting %s %s", version.PlatformName, version.FullVersion())
 	r := &f.ContainerRuntimeOptions
 
 	// Initialize docker client configuration.

--- a/core/image_linux.go
+++ b/core/image_linux.go
@@ -35,7 +35,7 @@ func (ds *dockerService) ImageFsInfo(
 	_ context.Context,
 	_ *runtimeapi.ImageFsInfoRequest,
 ) (*runtimeapi.ImageFsInfoResponse, error) {
-	info, err := ds.client.Info()
+	info, err := ds.getDockerInfo()
 	if err != nil {
 		logrus.Error(err, "Failed to get docker info")
 		return nil, err

--- a/core/logs.go
+++ b/core/logs.go
@@ -136,7 +136,7 @@ var criSupportedLogDrivers = []string{"json-file"}
 // IsCRISupportedLogDriver checks whether the logging driver used by docker is
 // supported by native CRI integration.
 func (ds *dockerService) IsCRISupportedLogDriver() (bool, error) {
-	info, err := ds.client.Info()
+	info, err := ds.getDockerInfo()
 	if err != nil {
 		return false, fmt.Errorf("failed to get docker info: %v", err)
 	}

--- a/core/stats_linux.go
+++ b/core/stats_linux.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (ds *dockerService) getContainerStats(containerID string) (*runtimeapi.ContainerStats, error) {
-	info, err := ds.client.Info()
+	info, err := ds.getDockerInfo()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- This is to reduce the load on docker daemon. 
In some cases, frequent `docker info` calls could lead to the system failure (high CPU, out-of-memory) due to many `GetTotalUsedFds` goroutines stuck in `getdents64` syscall. In addition, `docker version` calls `exec` to run OS commands for getting other binaries' version, this can also become a bottleneck on a busy node due to many goroutines contending a lock for forking a new process.
This PR caches `docker info` for 1 minute and tries best to get `docker version` from the cache.

- Also add version info in logs on starting. 