### PR TITLE
Pin the golang minor version

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 240
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.19.10
         uses: actions/setup-go@v1
         with:
-          go-version: 1.19
+          go-version: 1.19.10
         id: go
 
       - name: Setup Go binary path

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,10 +12,10 @@ jobs:
     timeout-minutes: 60
     steps:
 
-      - name: Set up Go 1.19
+      - name: Set up Go 1.19.10
         uses: actions/setup-go@v1
         with:
-          go-version: 1.19
+          go-version: 1.19.10
         id: go
 
       - name: Setup environment


### PR DESCRIPTION
The integration tests started failing due to a bug that went out in the recent 1.19.11 version of golang: https://github.com/moby/moby/issues/45935

This pins the integration tests to a specific minor version so that they will work. We can remove the minor version if we feel the need after the next version of golang is release with the fix.

```
Internal error occurred: error executing command in container: http: invalid Host header
```