### PR TITLE
Fix evaluation of usage for ImageFsInfo method

### DIFF
--- a/core/image_linux.go
+++ b/core/image_linux.go
@@ -41,7 +41,7 @@ func (ds *dockerService) ImageFsInfo(
 		return nil, err
 	}
 
-	bytes, inodes, err := dirSize(filepath.Join(info.DockerRootDir, "image"))
+	bytes, inodes, err := dirSize(filepath.Join(info.DockerRootDir, info.Driver))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`/var/lib/docker/images` doesn't contain images itself. So we have reports that far from even be rough calculation.

It should be improved by looking under the driver specific folders.