### PR TITLE
Migrate seccomp profile

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           repository: kubernetes-sigs/cri-tools
           path: src/sigs.k8s.io/cri-tools
-          ref: e3c99451faee42de2fcf4568bdd81be8bb29e40f
+          ref: 5fd98895f3bbf8a3ba2d25e93fa95ba1e2ae0923
 
       - name: Build cri-tools
         working-directory: src/sigs.k8s.io/cri-tools

--- a/core/container_create.go
+++ b/core/container_create.go
@@ -116,7 +116,7 @@ func (ds *dockerService) CreateContainer(
 	hc.Resources.Devices = devices
 
 	securityOpts, err := ds.getSecurityOpts(
-		config.GetLinux().GetSecurityContext().GetSeccompProfilePath(),
+		config.GetLinux().GetSecurityContext().GetSeccomp(),
 		securityOptSeparator,
 	)
 	if err != nil {

--- a/core/security_context.go
+++ b/core/security_context.go
@@ -21,15 +21,17 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
-	"github.com/Mirantis/cri-dockerd/config"
 	"io/ioutil"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/Mirantis/cri-dockerd/config"
+
 	dockercontainer "github.com/docker/docker/api/types/container"
 
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	knetwork "github.com/Mirantis/cri-dockerd/network"
 )
@@ -248,24 +250,25 @@ func modifyHostOptionsForContainer(
 	}
 }
 
-func getSeccompDockerOpts(seccompProfile string) ([]DockerOpt, error) {
-	if seccompProfile == "" || seccompProfile == config.SeccompProfileNameUnconfined {
+func getSeccompDockerOpts(seccomp *v1.SecurityProfile) ([]DockerOpt, error) {
+
+	if seccomp == nil || seccomp.GetProfileType() == v1.SecurityProfile_Unconfined {
 		// return early the default
 		return defaultSeccompOpt, nil
 	}
 
-	if seccompProfile == config.SeccompProfileRuntimeDefault ||
-		seccompProfile == config.DeprecatedSeccompProfileDockerDefault {
+	if seccomp.GetProfileType() == v1.SecurityProfile_RuntimeDefault ||
+		seccomp.GetProfileType().String() == config.DeprecatedSeccompProfileDockerDefault {
 		// return nil so docker will load the default seccomp profile
 		return nil, nil
 	}
 
-	if !strings.HasPrefix(seccompProfile, config.SeccompLocalhostProfileNamePrefix) {
-		return nil, fmt.Errorf("unknown seccomp profile option: %s", seccompProfile)
+	if seccomp.GetProfileType() != v1.SecurityProfile_Localhost {
+		return nil, fmt.Errorf("unknown seccomp profile option: %s", seccomp)
 	}
 
 	// get the full path of seccomp profile when prefixed with 'localhost/'.
-	fname := strings.TrimPrefix(seccompProfile, config.SeccompLocalhostProfileNamePrefix)
+	fname := seccomp.GetLocalhostRef()
 	if !filepath.IsAbs(fname) {
 		return nil, fmt.Errorf(
 			"seccomp profile path must be absolute, but got relative path %q",
@@ -289,7 +292,7 @@ func getSeccompDockerOpts(seccompProfile string) ([]DockerOpt, error) {
 
 // getSeccompSecurityOpts gets container seccomp options from container seccomp profile.
 // It is an experimental feature and may be promoted to official runtime api in the future.
-func getSeccompSecurityOpts(seccompProfile string, separator rune) ([]string, error) {
+func getSeccompSecurityOpts(seccompProfile *v1.SecurityProfile, separator rune) ([]string, error) {
 	seccompOpts, err := getSeccompDockerOpts(seccompProfile)
 	if err != nil {
 		return nil, err

--- a/core/security_context.go
+++ b/core/security_context.go
@@ -31,7 +31,6 @@ import (
 	dockercontainer "github.com/docker/docker/api/types/container"
 
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
-	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	knetwork "github.com/Mirantis/cri-dockerd/network"
 )
@@ -250,20 +249,20 @@ func modifyHostOptionsForContainer(
 	}
 }
 
-func getSeccompDockerOpts(seccomp *v1.SecurityProfile) ([]DockerOpt, error) {
+func getSeccompDockerOpts(seccomp *runtimeapi.SecurityProfile) ([]DockerOpt, error) {
 
-	if seccomp == nil || seccomp.GetProfileType() == v1.SecurityProfile_Unconfined {
+	if seccomp == nil || seccomp.GetProfileType() == runtimeapi.SecurityProfile_Unconfined {
 		// return early the default
 		return defaultSeccompOpt, nil
 	}
 
-	if seccomp.GetProfileType() == v1.SecurityProfile_RuntimeDefault ||
+	if seccomp.GetProfileType() == runtimeapi.SecurityProfile_RuntimeDefault ||
 		seccomp.GetProfileType().String() == config.DeprecatedSeccompProfileDockerDefault {
 		// return nil so docker will load the default seccomp profile
 		return nil, nil
 	}
 
-	if seccomp.GetProfileType() != v1.SecurityProfile_Localhost {
+	if seccomp.GetProfileType() != runtimeapi.SecurityProfile_Localhost {
 		return nil, fmt.Errorf("unknown seccomp profile option: %s", seccomp)
 	}
 
@@ -292,7 +291,7 @@ func getSeccompDockerOpts(seccomp *v1.SecurityProfile) ([]DockerOpt, error) {
 
 // getSeccompSecurityOpts gets container seccomp options from container seccomp profile.
 // It is an experimental feature and may be promoted to official runtime api in the future.
-func getSeccompSecurityOpts(seccompProfile *v1.SecurityProfile, separator rune) ([]string, error) {
+func getSeccompSecurityOpts(seccompProfile *runtimeapi.SecurityProfile, separator rune) ([]string, error) {
 	seccompOpts, err := getSeccompDockerOpts(seccompProfile)
 	if err != nil {
 		return nil, err

--- a/core/security_context_linux.go
+++ b/core/security_context_linux.go
@@ -21,10 +21,10 @@ package core
 import (
 	"fmt"
 
-	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-func (ds *dockerService) getSecurityOpts(seccomp *v1.SecurityProfile, separator rune) ([]string, error) {
+func (ds *dockerService) getSecurityOpts(seccomp *runtimeapi.SecurityProfile, separator rune) ([]string, error) {
 	// Apply seccomp options.
 	seccompSecurityOpts, err := getSeccompSecurityOpts(seccomp, separator)
 	if err != nil {

--- a/core/security_context_linux.go
+++ b/core/security_context_linux.go
@@ -20,11 +20,13 @@ package core
 
 import (
 	"fmt"
+
+	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-func (ds *dockerService) getSecurityOpts(seccompProfile string, separator rune) ([]string, error) {
+func (ds *dockerService) getSecurityOpts(seccomp *v1.SecurityProfile, separator rune) ([]string, error) {
 	// Apply seccomp options.
-	seccompSecurityOpts, err := getSeccompSecurityOpts(seccompProfile, separator)
+	seccompSecurityOpts, err := getSeccompSecurityOpts(seccomp, separator)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate seccomp security options for container: %v", err)
 	}


### PR DESCRIPTION
The method for retrieving the secomp profile path was deprecated in favor of a structure for managing a security profile. This change migrates the code to use the structure rather than the method to get the profile path and do string parsing to determine what profile type is being used. This is now handled using the structure and its methods.

This fixes integration tests related to #198 and moves the pinned integration cri-tools SHA to include tests for these changes.