### PR TITLE
fix(server): write version and buildinfo to stdout

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -81,7 +81,7 @@ func NewDockerCRICommand(stopCh <-chan struct{}) *cobra.Command {
 			verflag, _ := cleanFlagSet.GetBool("version")
 			if verflag {
 				fmt.Fprintf(
-					cmd.OutOrStderr(),
+					cmd.OutOrStdout(),
 					"%s %s\n",
 					version.PlatformName,
 					version.FullVersion(),
@@ -92,7 +92,7 @@ func NewDockerCRICommand(stopCh <-chan struct{}) *cobra.Command {
 			infoflag, _ := cleanFlagSet.GetBool("buildinfo")
 			if infoflag {
 				fmt.Fprintf(
-					cmd.OutOrStderr(),
+					cmd.OutOrStdout(),
 					"Program: %s\nVersion: %s\nGitCommit: %s\nGo version: %s\n",
 					version.PlatformName,
 					version.FullVersion(),


### PR DESCRIPTION
The command `cri-dockerd --version` and `cri-dockerd --buildinfo` output to stderr. The commands do not fail and have a 0 exit code. The stderr output also throws off common shell scripts which may expect the output to go to stdout, because most of the world does that.

This PR changes the preferred output stream to stdout for the above commands.

Fixes #186 

