### PR TITLE
Switch stat logging to debugf()

### DIFF
--- a/core/imagefs_linux.go
+++ b/core/imagefs_linux.go
@@ -40,7 +40,7 @@ func (ds *dockerService) imageFsInfo() (*runtimeapi.ImageFsInfoResponse, error) 
 	}
 	usedBytes := (stat.Blocks - stat.Bfree) * uint64(stat.Bsize)
 	iNodesUsed := stat.Files - stat.Ffree
-	logrus.Infof("Filesystem usage containing '%s': usedBytes=%v, iNodesUsed=%v", ds.dockerRootDir, usedBytes, iNodesUsed)
+	logrus.Debugf("Filesystem usage containing '%s': usedBytes=%v, iNodesUsed=%v", ds.dockerRootDir, usedBytes, iNodesUsed)
 
 	// compute total used bytes by docker images
 	images, err := ds.client.ListImages(types.ImageListOptions{All: true, SharedSize: true})
@@ -61,7 +61,7 @@ func (ds *dockerService) imageFsInfo() (*runtimeapi.ImageFsInfoResponse, error) 
 	for k := range sharedSizeMap {
 		totalImageSize += uint64(k)
 	}
-	logrus.Infof("Total used bytes by docker images: %v", totalImageSize)
+	logrus.Debugf("Total used bytes by docker images: %v", totalImageSize)
 
 	return &runtimeapi.ImageFsInfoResponse{
 		ImageFilesystems: []*runtimeapi.FilesystemUsage{

--- a/core/stats.go
+++ b/core/stats.go
@@ -175,7 +175,6 @@ func (ds *dockerService) ListContainerStats(
 	r *runtimeapi.ListContainerStatsRequest,
 ) (*runtimeapi.ListContainerStatsResponse, error) {
 	start := time.Now()
-	logrus.Info("Begin ListContainerStats")
 	containerStatsFilter := r.GetFilter()
 	filter := &runtimeapi.ContainerFilter{}
 
@@ -194,7 +193,7 @@ func (ds *dockerService) ListContainerStats(
 	containers := res.Containers
 	ds.containerStatsCache.clist <- containers
 	numContainers := len(containers)
-	logrus.Infof("Number of pod containers: %v", numContainers)
+	logrus.Debugf("Number of pod containers: %v", numContainers)
 	if numContainers == 0 {
 		return &runtimeapi.ListContainerStatsResponse{}, nil
 	}
@@ -242,7 +241,7 @@ func (ds *dockerService) ListContainerStats(
 		return nil, err
 	}
 
-	logrus.Infof("End ListContainerStats. Number of stats:%v, Time taken: %v", len(results), time.Since(start))
+	logrus.Debugf("Number of stats:%v, Time taken: %v", len(results), time.Since(start))
 
 	return &runtimeapi.ListContainerStatsResponse{Stats: results}, nil
 }


### PR DESCRIPTION
Fixes #258 

Logs before making this change:
```
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Connecting to docker on the Endpoint unix:///var/run/docker.sock"
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Start docker client with request timeout 0s"
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Hairpin mode is set to hairpin-veth"
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Loaded network plugin cni"
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Docker cri networking managed by network plugin cni"
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Setting cgroupDriver systemd"
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Docker cri received runtime config &RuntimeConfig{NetworkConfig:&NetworkConfig{PodCidr:,},}"
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Starting the GRPC backend for the Docker CRI interface."
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Start cri-dockerd grpc backend"
...
Oct 16 16:02:01 minikube cri-dockerd[2695]: time="2023-10-16T16:02:01Z" level=info msg="Number of pod containers: 8"
Oct 16 16:02:02 minikube cri-dockerd[2695]: time="2023-10-16T16:02:02Z" level=info msg="End ListContainerStats. Number of stats:8, Time taken: 1.010881467s"
Oct 16 16:02:12 minikube cri-dockerd[2695]: time="2023-10-16T16:02:12Z" level=info msg="Begin ListContainerStats"
Oct 16 16:02:12 minikube cri-dockerd[2695]: time="2023-10-16T16:02:12Z" level=info msg="Number of pod containers: 8"
Oct 16 16:02:13 minikube cri-dockerd[2695]: time="2023-10-16T16:02:13Z" level=info msg="End ListContainerStats. Number of stats:8, Time taken: 1.019785021s"
Oct 16 16:02:23 minikube cri-dockerd[2695]: time="2023-10-16T16:02:23Z" level=info msg="Filesystem usage containing '/var/lib/docker': usedBytes=214736613376, iNodesUsed=4770289"
Oct 16 16:02:23 minikube cri-dockerd[2695]: time="2023-10-16T16:02:23Z" level=info msg="Total used bytes by docker images: 736076745"
Oct 16 16:02:23 minikube cri-dockerd[2695]: time="2023-10-16T16:02:23Z" level=info msg="Begin ListContainerStats"
Oct 16 16:02:23 minikube cri-dockerd[2695]: time="2023-10-16T16:02:23Z" level=info msg="Number of pod containers: 8"
Oct 16 16:02:24 minikube cri-dockerd[2695]: time="2023-10-16T16:02:24Z" level=info msg="End ListContainerStats. Number of stats:8, Time taken: 1.019527026s"
....
```

Logs after:
```
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Connecting to docker on the Endpoint unix:///var/run/docker.sock"
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Start docker client with request timeout 0s"
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Hairpin mode is set to hairpin-veth"
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Loaded network plugin cni"
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Docker cri networking managed by network plugin cni"
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Setting cgroupDriver systemd"
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Docker cri received runtime config &RuntimeConfig{NetworkConfig:&NetworkConfig{PodCidr:,},}"
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Starting the GRPC backend for the Docker CRI interface."
Oct 16 16:30:14 minikube cri-dockerd[3700]: time="2023-10-16T16:30:14Z" level=info msg="Start cri-dockerd grpc backend"
```
## Proposed Changes

  - Change stats logging calls to `debugf()`
