### PR TITLE
Add LICENSE file to RPMs

### DIFF
--- a/packaging/rpm/Makefile
+++ b/packaging/rpm/Makefile
@@ -39,7 +39,7 @@ RPMBUILD_FLAGS?=-ba\
 	$(SPECS)
 RUN?=$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 
-SOURCE_FILES=app.tgz cri-docker.service cri-docker.socket
+SOURCE_FILES=app.tgz cri-docker.service cri-docker.socket LICENSE
 SOURCES=$(addprefix rpmbuild/SOURCES/, $(SOURCE_FILES))
 
 FEDORA_RELEASES := fedora-36 fedora-35
@@ -87,5 +87,9 @@ rpmbuild/SOURCES/cri-docker.service: ../systemd/cri-docker.service
 	cp $< $@
 
 rpmbuild/SOURCES/cri-docker.socket: ../systemd/cri-docker.socket
+	mkdir -p $(@D)
+	cp $< $@
+
+rpmbuild/SOURCES/LICENSE: ../../LICENSE
 	mkdir -p $(@D)
 	cp $< $@

--- a/packaging/rpm/SPECS/cri-dockerd.spec
+++ b/packaging/rpm/SPECS/cri-dockerd.spec
@@ -8,6 +8,7 @@ Epoch: 3
 Source0: app.tgz
 Source1: cri-docker.service
 Source2: cri-docker.socket
+Source3: LICENSE
 Summary: A CRI interface for Docker
 Group: Tools/Docker
 License: ASL 2.0
@@ -75,6 +76,9 @@ install -D -p -m 0755 $(readlink -f app/cri-dockerd) $RPM_BUILD_ROOT/%{_bindir}/
 # install systemd scripts
 install -D -m 0644 %{_topdir}/SOURCES/cri-docker.service $RPM_BUILD_ROOT/%{_unitdir}/cri-docker.service
 install -D -m 0644 %{_topdir}/SOURCES/cri-docker.socket $RPM_BUILD_ROOT/%{_unitdir}/cri-docker.socket
+
+# install license
+install -D -m 0644 %{_topdir}/SOURCES/LICENSE $RPM_BUILD_ROOT/LICENSE
 
 %files
 /%{_bindir}/cri-dockerd

--- a/packaging/rpm/SPECS/cri-dockerd.spec
+++ b/packaging/rpm/SPECS/cri-dockerd.spec
@@ -80,6 +80,7 @@ install -D -m 0644 %{_topdir}/SOURCES/cri-docker.socket $RPM_BUILD_ROOT/%{_unitd
 /%{_bindir}/cri-dockerd
 /%{_unitdir}/cri-docker.service
 /%{_unitdir}/cri-docker.socket
+%license LICENSE
 
 %post
 %systemd_post cri-docker.service

--- a/packaging/rpm/SPECS/cri-dockerd.spec
+++ b/packaging/rpm/SPECS/cri-dockerd.spec
@@ -60,6 +60,7 @@ cri-dockerd is a lightweight implementation of the CRI specification which talks
 %setup -q -c -n src -a 0
 
 %build
+cp %{_topdir}/SOURCES/LICENSE /root/rpmbuild/BUILD/src/LICENSE
 export CRI_DOCKER_GITCOMMIT=%{_gitcommit}
 mkdir -p /go/src/github.com/Mirantis
 ln -s /root/rpmbuild/BUILD/src/app /go/src/github.com/Mirantis/cri-dockerd
@@ -76,9 +77,6 @@ install -D -p -m 0755 $(readlink -f app/cri-dockerd) $RPM_BUILD_ROOT/%{_bindir}/
 # install systemd scripts
 install -D -m 0644 %{_topdir}/SOURCES/cri-docker.service $RPM_BUILD_ROOT/%{_unitdir}/cri-docker.service
 install -D -m 0644 %{_topdir}/SOURCES/cri-docker.socket $RPM_BUILD_ROOT/%{_unitdir}/cri-docker.socket
-
-# install license
-install -D -m 0644 %{_topdir}/SOURCES/LICENSE $RPM_BUILD_ROOT/LICENSE
 
 %files
 /%{_bindir}/cri-dockerd


### PR DESCRIPTION
Fixes #266 

This adds the LICENSE files to RPMs.

Unfortunately I haven't been able to get the RPM builds working locally so I've not been able to test it, though it should "just work". (That assumes all target distros have rpm 4.11 or above; if not, %doc would be a suitable alternative.)
