### PR TITLE
Bump go image to 1.19.10

### DIFF
--- a/packaging/common.mk
+++ b/packaging/common.mk
@@ -1,5 +1,5 @@
 ARCH=$(shell uname -m)
-GO_VERSION:=1.18.3
+GO_VERSION:=1.19.10
 PLATFORM=cri-dockerd
 SHELL:=/bin/bash
 VERSION?=0.3.6-dev


### PR DESCRIPTION
The release build is broken due to a library update with https://github.com/Mirantis/cri-dockerd/pull/260. One of the libraries now requires go 1.19+. This bumps the go image to the most recent 1.19.x version.

I didn't go for a more recent go version because there is not a debian image for us to use and it will require more updates and conversations on what platforms are supported.

## Proposed Changes

  - Bump the golang image to 1.19.10
