### PR TITLE
Fix the ReadDir methods

### DIFF
--- a/config/os.go
+++ b/config/os.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -36,7 +35,7 @@ type OSInterface interface {
 	Hostname() (name string, err error)
 	Chtimes(path string, atime time.Time, mtime time.Time) error
 	Pipe() (r *os.File, w *os.File, err error)
-	ReadDir(dirname string) ([]os.FileInfo, error)
+	ReadDir(dirname string) ([]os.DirEntry, error)
 	Glob(pattern string) ([]string, error)
 	Open(name string) (*os.File, error)
 	OpenFile(name string, flag int, perm os.FileMode) (*os.File, error)
@@ -99,8 +98,8 @@ func (RealOS) Pipe() (r *os.File, w *os.File, err error) {
 }
 
 // ReadDir will call ioutil.ReadDir to return the files under the directory.
-func (RealOS) ReadDir(dirname string) ([]os.FileInfo, error) {
-	return ioutil.ReadDir(dirname)
+func (RealOS) ReadDir(dirname string) ([]os.DirEntry, error) {
+	return os.ReadDir(dirname)
 }
 
 // Glob will call filepath.Glob to return the names of all files matching

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/container/testing/os.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/container/testing/os.go
@@ -28,7 +28,7 @@ import (
 // of the real call.
 type FakeOS struct {
 	StatFn     func(string) (os.FileInfo, error)
-	ReadDirFn  func(string) ([]os.FileInfo, error)
+	ReadDirFn  func(string) ([]os.DirEntry, error)
 	MkdirAllFn func(string, os.FileMode) error
 	SymlinkFn  func(string, string) error
 	GlobFn     func(string, string) bool
@@ -106,7 +106,7 @@ func (*FakeOS) Pipe() (r *os.File, w *os.File, err error) {
 }
 
 // ReadDir is a fake call that returns the files under the directory.
-func (f *FakeOS) ReadDir(dirname string) ([]os.FileInfo, error) {
+func (f *FakeOS) ReadDir(dirname string) ([]os.DirEntry, error) {
 	if f.ReadDirFn != nil {
 		return f.ReadDirFn(dirname)
 	}


### PR DESCRIPTION
During #280 a package file accidentally got modified. This made CI pass but when dependabot tries to run `go mod vendor`, it updates the package and causes failures. This PR straightens this out so that packages can be updated and tests will now pass.

## Proposed Changes

  - Change the `OSInterface` interface so that `ReadDir()` is updated so that `FakeOS` can be used again
