### PR TITLE
Add bookworm build

### DIFF
--- a/packaging/deb/Makefile
+++ b/packaging/deb/Makefile
@@ -36,7 +36,7 @@ RUN=docker run --rm -i \
 SOURCE_FILES=app.tgz cri-docker.service cri-docker.socket
 SOURCES=$(addprefix sources/, $(SOURCE_FILES))
 
-DEBIAN_VERSIONS := debian-bullseye
+DEBIAN_VERSIONS := debian-bullseye debian-bookworm
 #UBUNTU_VERSIONS := ubuntu-xenial ubuntu-bionic ubuntu-cosmic ubuntu-disco ubuntu-eoan
 UBUNTU_VERSIONS := ubuntu-bionic ubuntu-focal ubuntu-jammy
 RASPBIAN_VERSIONS := raspbian-bullseye

--- a/packaging/deb/debian-bookworm/Dockerfile
+++ b/packaging/deb/debian-bookworm/Dockerfile
@@ -1,0 +1,34 @@
+ARG GO_IMAGE
+ARG DISTRO=debian
+ARG SUITE=bookworm
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y curl devscripts equivs git
+
+ENV GOPROXY=direct
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
+RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+
+COPY sources/ /sources
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+
+COPY --from=golang /usr/local/go /usr/local/go
+
+WORKDIR /root/build-deb
+COPY build-deb /root/build-deb/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]


### PR DESCRIPTION
Fixes #276 

Adds a bookworm deb file to be built during a release.

## Proposed Changes

  - Build bookworm deb also
