### PR TITLE
Update SELinux golang version

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -188,6 +188,6 @@ jobs:
 
       - run: rsync -a -e ssh src/github.com/Mirantis/cri-dockerd/ lima-default:/tmp/cri-dockerd
       - run: ssh lima-default sudo /tmp/cri-dockerd/scripts/setup-el
-      - run: ssh lima-default make -C /tmp/cri-dockerd cri-dockerd
+      - run: ssh lima-default "source ~/.bashrc && make -C /tmp/cri-dockerd cri-dockerd"
       - run: ssh -f lima-default sudo /tmp/cri-dockerd/cri-dockerd --network-plugin="" &
       - run: ssh lima-default sudo /usr/local/bin/critest -runtime-endpoint=unix:///var/run/cri-dockerd.sock -ginkgo.focus='.*selinux.*' -ginkgo.v

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -188,6 +188,6 @@ jobs:
 
       - run: rsync -a -e ssh src/github.com/Mirantis/cri-dockerd/ lima-default:/tmp/cri-dockerd
       - run: ssh lima-default sudo /tmp/cri-dockerd/scripts/setup-el
-      - run: ssh lima-default "source ~/.bashrc && make -C /tmp/cri-dockerd cri-dockerd"
+      - run: ssh lima-default "export PATH=$PATH:/usr/local/go/bin && make -C /tmp/cri-dockerd cri-dockerd"
       - run: ssh -f lima-default sudo /tmp/cri-dockerd/cri-dockerd --network-plugin="" &
       - run: ssh lima-default sudo /usr/local/bin/critest -runtime-endpoint=unix:///var/run/cri-dockerd.sock -ginkgo.focus='.*selinux.*' -ginkgo.v

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -184,7 +184,7 @@ jobs:
         run: |
           limactl start --name=default --plain template://rocky-8
           mkdir -p -m 0700 ~/.ssh
-          cat ~/.lima/default/ssh.config >>~/.ssh/config
+          cat ~/.lima/default/ssh.config >> ~/.ssh/config
 
       - run: rsync -a -e ssh src/github.com/Mirantis/cri-dockerd/ lima-default:/tmp/cri-dockerd
       - run: ssh lima-default sudo /tmp/cri-dockerd/scripts/setup-el

--- a/scripts/setup-el
+++ b/scripts/setup-el
@@ -9,8 +9,16 @@ mkdir -p /etc/docker
 cat <<EOF >/etc/docker/daemon.json
 {"selinux-enabled": true}
 EOF
+
+echo "Installing Golang"
+curl -O https://dl.google.com/go/go1.22.1.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.22.1.linux-amd64.tar.gz
+echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.bashrc
+. ~/.bashrc
+
+echo "Installing other dependencies"
 dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-dnf install -y docker-ce git golang make
+dnf install -y docker-ce git make
 sudo systemctl enable --now docker
 
 echo "Installing cri-tools"

--- a/scripts/setup-el
+++ b/scripts/setup-el
@@ -13,7 +13,6 @@ EOF
 echo "Installing Golang"
 curl -O https://dl.google.com/go/go1.22.1.linux-amd64.tar.gz
 sudo tar -C /usr/local -xzf go1.22.1.linux-amd64.tar.gz
-echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.bashrc
 export PATH=$PATH:/usr/local/go/bin
 
 echo "Installing other dependencies"

--- a/scripts/setup-el
+++ b/scripts/setup-el
@@ -14,7 +14,7 @@ echo "Installing Golang"
 curl -O https://dl.google.com/go/go1.22.1.linux-amd64.tar.gz
 sudo tar -C /usr/local -xzf go1.22.1.linux-amd64.tar.gz
 echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.bashrc
-. ~/.bashrc
+export PATH=$PATH:/usr/local/go/bin
 
 echo "Installing other dependencies"
 dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo


### PR DESCRIPTION
SELinux test is failing due to cri-tools requiring a golang version >1.21. This test is currently using go from the dnf repo. This change is to manually install go so that a newer version can be used.

## Proposed Changes

  - Use the same golang version as the other CI workflows
