### PR TITLE
Add nil check for result of getContainerStats

### DIFF
--- a/core/stats.go
+++ b/core/stats.go
@@ -169,6 +169,9 @@ func (ds *dockerService) ContainerStats(
 	if err != nil {
 		return nil, err
 	}
+	if stats == nil {
+		return nil, fmt.Errorf("stats for container with id %s not available", r.ContainerId)
+	}
 	return &runtimeapi.ContainerStatsResponse{Stats: stats}, nil
 }
 
@@ -232,7 +235,9 @@ func (ds *dockerService) ListContainerStats(
 				return nil
 			}
 			mu.Lock()
-			results = append(results, stats)
+			if stats != nil {
+				results = append(results, stats)
+			}
 			mu.Unlock()
 			return nil
 		})


### PR DESCRIPTION
On Windows, `ds.getContainerStats` could return [nil](https://github.com/Mirantis/cri-dockerd/blob/7b5b6d4698f453994585d9911d551d029a5c38ce/core/stats_windows.go#L41) for stopped containers. 

Fixes #330

## Proposed Changes

  - Check nil on the result of `ds.getContainerStats`
 
