### PR TITLE
Bump up minimum Docker API to v1.42 (Docker v23)

### DIFF
--- a/libdocker/client.go
+++ b/libdocker/client.go
@@ -31,8 +31,9 @@ import (
 
 const (
 	// https://docs.docker.com/engine/reference/api/docker_remote_api/
-	// docker version should be at least 1.13.1
-	MinimumDockerAPIVersion = "1.26.0"
+	// docker version should be at least 23.0.0.
+	// https://github.com/moby/moby/commit/304fbf080465e7097a6ab16b1f2a540d02bc7d75
+	MinimumDockerAPIVersion = "1.42.0"
 
 	// Status of a container returned by ListContainers.
 	StatusRunningPrefix = "Up"

--- a/libdocker/fake_client.go
+++ b/libdocker/fake_client.go
@@ -83,7 +83,7 @@ type FakeDockerClient struct {
 
 const (
 	// Notice that if someday we also have minimum docker version requirement, this should also be updated.
-	fakeDockerVersion = "1.13.1"
+	fakeDockerVersion = "23.0.0"
 
 	fakeImageSize = 1024
 


### PR DESCRIPTION
`CreateMountpoint` in `libdocker/helpers.go:GenerateMountBindings()` depends on API v1.42 (Docker v23)

https://github.com/moby/moby/commit/304fbf080465e7097a6ab16b1f2a540d02bc7d75

Prior versions of Docker and Mirantis Container Engine seem to have already reached EOL.


