### PR TITLE
add User=root to systemd, this will set the HOME=/root

### DIFF
--- a/packaging/systemd/cri-docker.service
+++ b/packaging/systemd/cri-docker.service
@@ -7,6 +7,7 @@ Requires=cri-docker.socket
 
 [Service]
 Type=notify
+User=root
 ExecStart=/usr/bin/cri-dockerd --container-runtime-endpoint fd://
 ExecReload=/bin/kill -s HUP $MAINPID
 TimeoutSec=0


### PR DESCRIPTION
It will help find the docker configuration file and pull the pause image that requires certification.

Fixes # https://github.com/Mirantis/cri-dockerd/issues/232

## Proposed Changes

debug info

```
(dlv) c
> k8s.io/kubernetes/pkg/credentialprovider.ReadDockerConfigJSONFile() ./vendor/k8s.io/kubernetes/pkg/credentialprovider/config.go:138 (hits goroutine(677):1 total:1) (PC: 0x2285942)
   133:	// if searchPaths is empty, the default paths are used.
   134:	func ReadDockerConfigJSONFile(searchPaths []string) (cfg DockerConfig, err error) {
   135:		if len(searchPaths) == 0 {
   136:			searchPaths = DefaultDockerConfigJSONPaths()
   137:		}
=> 138:		for _, configPath := range searchPaths {
   139:			absDockerConfigFileLocation, err := filepath.Abs(filepath.Join(configPath, configJSONFileName))
   140:			if err != nil {
   141:				klog.Errorf("while trying to canonicalize %s: %v", configPath, err)
   142:				continue
   143:			}
(dlv) p searchPaths
[]string len: 4, cap: 4, [
	"",
	"",
	".docker",
	"/.docker",
]
(dlv) p homeJSONDirPath
".docker"
(dlv) call os.UserHomeDir()
> k8s.io/kubernetes/pkg/credentialprovider.ReadDockerConfigJSONFile() ./vendor/k8s.io/kubernetes/pkg/credentialprovider/config.go:138 (PC: 0x2285942)
Values returned:
	~r0: ""
	~r1: error(*errors.errorString) *{
		s: "$HOME is not defined",}
```

find there is no `HOME` onder systemd:
```
$ xargs -0 -n1 < /proc/$(pgrep cri-dockerd)/environ
LANG=en_US.UTF-8
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
NOTIFY_SOCKET=/run/systemd/notify
LISTEN_PID=5894
LISTEN_FDS=1
```