### PR TITLE
support RuntimeClass.handler, this will useful like nvidia is not the…

### DIFF
--- a/core/container_create.go
+++ b/core/container_create.go
@@ -67,6 +67,11 @@ func (ds *dockerService) CreateContainer(
 	containerName := makeContainerName(sandboxConfig, config)
 	mounts := config.GetMounts()
 	terminationMessagePath, _ := config.Annotations["io.kubernetes.container.terminationMessagePath"]
+
+	sandboxInfo, err := ds.client.InspectContainer(r.GetPodSandboxId())
+	if err != nil {
+		return nil, fmt.Errorf("unable to get container's sandbox ID: %v", err)
+	}
 	createConfig := dockerbackend.ContainerCreateConfig{
 		Name: containerName,
 		Config: &container.Config{
@@ -91,6 +96,7 @@ func (ds *dockerService) CreateContainer(
 			RestartPolicy: container.RestartPolicy{
 				Name: "no",
 			},
+			Runtime: sandboxInfo.HostConfig.Runtime,
 		},
 	}
 

--- a/core/docker_service.go
+++ b/core/docker_service.go
@@ -286,6 +286,8 @@ type dockerService struct {
 	// methods for more info).
 	containerCleanupInfos map[string]*containerCleanupInfo
 	cleanupInfosLock      sync.RWMutex
+
+	// runtimeInfoLock sync.RWMutex
 }
 
 type dockerServiceAlpha struct {

--- a/core/sandbox_helpers.go
+++ b/core/sandbox_helpers.go
@@ -58,6 +58,24 @@ var (
 	defaultSandboxGracePeriod = time.Duration(10) * time.Second
 )
 
+// check Runtime correct
+func (ds *dockerService) IsRuntimeConfigured(runtime string) error {
+	info, err := ds.getDockerInfo()
+	if err != nil {
+		return fmt.Errorf("failed to get docker info: %v", err)
+	}
+
+	// ds.runtimeInfoLock.RLock()
+	for r := range info.Runtimes {
+		if r == runtime {
+			return nil
+		}
+	}
+	// ds.runtimeInfoLock.RUnlock()
+
+	return fmt.Errorf("no runtime for %q is configured", runtime)
+}
+
 // Returns whether the sandbox network is ready, and whether the sandbox is known
 func (ds *dockerService) getNetworkReady(podSandboxID string) (bool, bool) {
 	ds.networkReadyLock.Lock()

--- a/core/sandbox_status.go
+++ b/core/sandbox_status.go
@@ -19,6 +19,7 @@ package core
 import (
 	"context"
 	"fmt"
+
 	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -81,6 +82,7 @@ func (ds *dockerService) PodSandboxStatus(
 				},
 			},
 		},
+		RuntimeHandler: r.HostConfig.Runtime,
 	}
 	// add additional IPs
 	additionalPodIPs := make([]*v1.PodIP, 0, len(ips))

--- a/libdocker/client.go
+++ b/libdocker/client.go
@@ -25,6 +25,7 @@ import (
 	dockercontainer "github.com/docker/docker/api/types/container"
 	dockerimagetypes "github.com/docker/docker/api/types/image"
 	dockerregistry "github.com/docker/docker/api/types/registry"
+	dockersystem "github.com/docker/docker/api/types/system"
 	dockerapi "github.com/docker/docker/client"
 	"github.com/sirupsen/logrus"
 )
@@ -46,7 +47,7 @@ const (
 
 // DockerClientInterface is an abstract interface for testability.  It abstracts the interface of docker client.
 type DockerClientInterface interface {
-	ListContainers(options dockertypes.ContainerListOptions) ([]dockertypes.Container, error)
+	ListContainers(options dockercontainer.ListOptions) ([]dockertypes.Container, error)
 	InspectContainer(id string) (*dockertypes.ContainerJSON, error)
 	InspectContainerWithSize(id string) (*dockertypes.ContainerJSON, error)
 	CreateContainer(
@@ -55,23 +56,23 @@ type DockerClientInterface interface {
 	StartContainer(id string) error
 	StopContainer(id string, timeout time.Duration) error
 	UpdateContainerResources(id string, updateConfig dockercontainer.UpdateConfig) error
-	RemoveContainer(id string, opts dockertypes.ContainerRemoveOptions) error
+	RemoveContainer(id string, opts dockercontainer.RemoveOptions) error
 	InspectImageByRef(imageRef string) (*dockertypes.ImageInspect, error)
 	InspectImageByID(imageID string) (*dockertypes.ImageInspect, error)
-	ListImages(opts dockertypes.ImageListOptions) ([]dockertypes.ImageSummary, error)
+	ListImages(opts dockertypes.ImageListOptions) ([]dockerimagetypes.Summary, error)
 	PullImage(image string, auth dockerregistry.AuthConfig, opts dockertypes.ImagePullOptions) error
 	RemoveImage(
 		image string,
 		opts dockertypes.ImageRemoveOptions,
-	) ([]dockertypes.ImageDeleteResponseItem, error)
+	) ([]dockerimagetypes.DeleteResponse, error)
 	ImageHistory(id string) ([]dockerimagetypes.HistoryResponseItem, error)
-	Logs(string, dockertypes.ContainerLogsOptions, StreamOptions) error
+	Logs(string, dockercontainer.LogsOptions, StreamOptions) error
 	Version() (*dockertypes.Version, error)
-	Info() (*dockertypes.Info, error)
+	Info() (*dockersystem.Info, error)
 	CreateExec(string, dockertypes.ExecConfig) (*dockertypes.IDResponse, error)
 	StartExec(string, dockertypes.ExecStartCheck, StreamOptions) error
 	InspectExec(id string) (*dockertypes.ContainerExecInspect, error)
-	AttachToContainer(string, dockertypes.ContainerAttachOptions, StreamOptions) error
+	AttachToContainer(string, dockercontainer.AttachOptions, StreamOptions) error
 	ResizeContainerTTY(id string, height, width uint) error
 	ResizeExecTTY(id string, height, width uint) error
 	GetContainerStats(id string) (*dockertypes.StatsJSON, error)


### PR DESCRIPTION
Fixes [#111](https://github.com/Mirantis/cri-dockerd/issues/111) . default-runtime is `runc`, You cannot use `RuntimeClass.handler` to specify that the pod uses a **non-runc** runtime.:
```
# curl -s --unix-socket /var/run/docker.sock http://./v1.42/info | jq .Runtimes
{
  "io.containerd.runc.v2": {
    "path": "runc"
  },
  "nvidia": {
    "path": "nvidia-container-runtime"
  },
  "runc": {
    "path": "runc"
  }
}
```

before

```
apiVersion: node.k8s.io/v1
kind: RuntimeClass
metadata:
  name: nvidia
handler: docker
---
apiVersion: v1
kind: Pod
metadata:
....
    spec:
      runtimeClassName: nvidia
```
`RuntimeClass.handler=docker` will used runc
```
docker inspect xx | grep Runtime:
            "Runtime": "runc",
```
change `handler: docker` to `handler: nvidia` will not work, but after this pr:
```
apiVersion: node.k8s.io/v1
kind: RuntimeClass
metadata:
  name: nvidia
handler: nvidia # <----
---
apiVersion: v1
kind: Pod
metadata:
....
    spec:
      runtimeClassName: nvidia
```
will handle the `RuntimeClass.handler`
```
docker inspect xx | grep Runtime:
            "Runtime": "nvidia",
```
work with crictl https://github.com/containerd/containerd/blob/main/docs/cri/crictl.md#run-a-pod-sandbox-using-a-config-file
```
$ cat sandbox-config.json 
{
    "metadata": {
        "name": "nginx-sandbox",
        "namespace": "default",
        "attempt": 1,
        "uid": "hdishd83djaidwnduwk28bcsb"
    },
    "linux": {
    }
}
$ crictl  runp --runtime runc111 sandbox-config.json 
E0420 22:22:04.460269    2703 remote_runtime.go:193] "RunPodSandbox from runtime service failed" err="rpc error: code = Unknown desc = failed to get sandbox runtime: no runtime for \"runc111\" is configured"
FATA[0000] run pod sandbox: rpc error: code = Unknown desc = failed to get sandbox runtime: no runtime for "runc111" is configured
$ crictl  runp --runtime runc sandbox-config.json 
e919f7425bc569ad823da6ffc799bac1318c0b1a1bef7568362ce7f1f10710af
```