### PR TITLE
set annotations when creating sanbodx and containers

### DIFF
--- a/core/container_create.go
+++ b/core/container_create.go
@@ -47,6 +47,8 @@ func (ds *dockerService) CreateContainer(
 		return nil, fmt.Errorf("sandbox config is nil for container %q", config.Metadata.Name)
 	}
 
+	// TODO: Docker supports annotations for now, so labels and annotations might be separated
+	//       in the future. Keeping them merged is just for backward compatibility.
 	labels := makeLabels(config.GetLabels(), config.GetAnnotations())
 	// Apply a the container type label.
 	labels[containerTypeLabelKey] = containerTypeLabelContainer
@@ -54,6 +56,12 @@ func (ds *dockerService) CreateContainer(
 	labels[containerLogPathLabelKey] = filepath.Join(sandboxConfig.LogDirectory, config.LogPath)
 	// Write the sandbox ID in the labels.
 	labels[sandboxIDLabelKey] = podSandboxID
+
+	// Set container annotations.
+	annotations := config.GetAnnotations()
+	annotations[containerTypeLabelKey] = containerTypeLabelContainer
+	annotations[containerLogPathLabelKey] = filepath.Join(sandboxConfig.LogDirectory, config.LogPath)
+	annotations[sandboxIDLabelKey] = podSandboxID
 
 	apiVersion, err := ds.getDockerAPIVersion()
 	if err != nil {
@@ -96,7 +104,8 @@ func (ds *dockerService) CreateContainer(
 			RestartPolicy: container.RestartPolicy{
 				Name: "no",
 			},
-			Runtime: sandboxInfo.HostConfig.Runtime,
+			Runtime:     sandboxInfo.HostConfig.Runtime,
+			Annotations: annotations,
 		},
 	}
 

--- a/core/container_status.go
+++ b/core/container_status.go
@@ -19,6 +19,7 @@ package core
 import (
 	"context"
 	"fmt"
+
 	"github.com/Mirantis/cri-dockerd/libdocker"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -114,7 +115,7 @@ func (ds *dockerService) ContainerStatus(
 		return nil, err
 	}
 
-	labels, annotations := extractLabels(r.Config.Labels)
+	labels, _ := extractLabels(r.Config.Labels)
 	imageName := r.Config.Image
 	if ir != nil && len(ir.RepoTags) > 0 {
 		imageName = ir.RepoTags[0]
@@ -133,7 +134,7 @@ func (ds *dockerService) ContainerStatus(
 		Reason:      reason,
 		Message:     message,
 		Labels:      labels,
-		Annotations: annotations,
+		Annotations: r.HostConfig.Annotations,
 		LogPath:     r.Config.Labels[containerLogPathLabelKey],
 	}
 	res := v1.ContainerStatusResponse{Status: status}

--- a/core/convert.go
+++ b/core/convert.go
@@ -202,6 +202,8 @@ func toRuntimeAPIContainer(c *dockertypes.Container) (*runtimeapi.Container, err
 	if err != nil {
 		return nil, err
 	}
+	// TODO: Currently docker ContainerList api doesn't return annotations, so annotations
+	//       still need to be extracted from labels here.
 	labels, annotations := extractLabels(c.Labels)
 	sandboxID := c.Labels[sandboxIDLabelKey]
 	// The timestamp in dockertypes.Container is in seconds.
@@ -269,6 +271,8 @@ func containerToRuntimeAPISandbox(c *dockertypes.Container) (*runtimeapi.PodSand
 	if err != nil {
 		return nil, err
 	}
+	// TODO: Currently docker ContainerList api doesn't return annotations, so annotations
+	//       still need to be extracted from labels here.
 	labels, annotations := extractLabels(c.Labels)
 	// The timestamp in dockertypes.Container is in seconds.
 	createdAt := c.Created * int64(time.Second)

--- a/core/sandbox_helpers.go
+++ b/core/sandbox_helpers.go
@@ -233,15 +233,21 @@ func (ds *dockerService) makeSandboxDockerConfig(
 	c *runtimeapi.PodSandboxConfig,
 	image string,
 ) (*dockerbackend.ContainerCreateConfig, error) {
-	// Merge annotations and labels because docker supports only labels.
+	// TODO: Docker supports annotations for now, so labels and annotations might be separated
+	//       in the future. Keeping them merged is just for backward compatibility.
 	labels := makeLabels(c.GetLabels(), c.GetAnnotations())
 	// Apply a label to distinguish sandboxes from regular containers.
 	labels[containerTypeLabelKey] = containerTypeLabelSandbox
 	// Apply a container name label for infra container. This is used in summary v1.
 	labels[config.KubernetesContainerNameLabel] = sandboxContainerName
 
+	// Set sandbox annotations.
+	annotations := c.GetAnnotations()
+	annotations[containerTypeLabelKey] = containerTypeLabelSandbox
+
 	hc := &dockercontainer.HostConfig{
-		IpcMode: dockercontainer.IpcMode("shareable"),
+		IpcMode:     dockercontainer.IpcMode("shareable"),
+		Annotations: annotations,
 	}
 	createConfig := &dockerbackend.ContainerCreateConfig{
 		Name: makeSandboxName(c),

--- a/core/sandbox_status.go
+++ b/core/sandbox_status.go
@@ -62,14 +62,14 @@ func (ds *dockerService) PodSandboxStatus(
 		ips = ips[1:]
 	}
 
-	labels, annotations := extractLabels(r.Config.Labels)
+	labels, _ := extractLabels(r.Config.Labels)
 	status := &v1.PodSandboxStatus{
 		Id:          r.ID,
 		State:       state,
 		CreatedAt:   ct,
 		Metadata:    metadata,
 		Labels:      labels,
-		Annotations: annotations,
+		Annotations: r.HostConfig.Annotations,
 		Network: &v1.PodSandboxNetworkStatus{
 			Ip: ip,
 		},


### PR DESCRIPTION
## Proposed Changes

Docker now allows client to set annotaion when creating sandbox and containers that is significant for some low-level runtimes(e.g. kata-containers) as they use it to determine whether the creating is a pod_sandbox or a pod_container.
