### PR TITLE
Remove centos 7 from CI

### DIFF
--- a/packaging/rpm/Makefile
+++ b/packaging/rpm/Makefile
@@ -43,7 +43,7 @@ SOURCE_FILES=app.tgz cri-docker.service cri-docker.socket LICENSE
 SOURCES=$(addprefix rpmbuild/SOURCES/, $(SOURCE_FILES))
 
 FEDORA_RELEASES := fedora-36 fedora-35
-CENTOS_RELEASES := centos-stream centos-7
+CENTOS_RELEASES :=
 
 .PHONY: help
 help: ## show make targets

--- a/packaging/rpm/centos-stream/Dockerfile
+++ b/packaging/rpm/centos-stream/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_IMAGE
-ARG DISTRO=tgagor/centos
-ARG SUITE=stream8
+ARG DISTRO=aepifanov/centos7.vault
+ARG SUITE=latest
 ARG BUILD_IMAGE=${DISTRO}:${SUITE}
 
 FROM ${GO_IMAGE} AS golang


### PR DESCRIPTION
Cent OS 7 repos have been archived causing the builds to fail

## Proposed Changes

  - Remove the option to build Cent OS 7
