### PR TITLE
Set CI docker version to 22.04

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   integration:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - name: Checkout cri-dockerd

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,7 +61,8 @@ jobs:
            stable"
           sudo apt-get update
           sudo apt-cache madison docker-ce
-          sudo apt-get install docker-ce docker-ce-cli containerd.io
+          VERSION_STRING=5:26.1.4-1~ubuntu.22.04~jammy
+          sudo apt-get install docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io
 
           # Restart docker daemon.
           sudo service docker restart


### PR DESCRIPTION
Fixes integration tests suddenly starting to fail in CI

## Proposed Changes

  - Bump the ubuntu test image to 22.04
