### PR TITLE
Update CI image to 24.04 and remove Cent OS 7

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   integration:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - name: Checkout cri-dockerd

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   integration:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - name: Checkout cri-dockerd

--- a/packaging/rpm/Makefile
+++ b/packaging/rpm/Makefile
@@ -43,7 +43,7 @@ SOURCE_FILES=app.tgz cri-docker.service cri-docker.socket LICENSE
 SOURCES=$(addprefix rpmbuild/SOURCES/, $(SOURCE_FILES))
 
 FEDORA_RELEASES := fedora-36 fedora-35
-CENTOS_RELEASES := centos-stream centos-7
+CENTOS_RELEASES :=
 
 .PHONY: help
 help: ## show make targets


### PR DESCRIPTION
CI has been failing due to it still using the Ubuntu 20.04 image and Cent OS 7 that has reached EOL.

## Proposed Changes

  - Remove EOL CentOS versions
  - Update the CI image to Ubuntu 24.04
