### PR TITLE
Bump actions/upload-artifact to v4 

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: logs
           path: logs


### PR DESCRIPTION
Fixes #414 

Bump the version of the artifact upload github action

## Proposed Changes

  - Bump action/upload-artifact from the deprecated v1 to v4