### PR TITLE
Bump all upload/download artifact GHAs to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Upload
       if: ${{ github.event_name == 'release' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cri-dockerd
         retention-days: 5
@@ -51,7 +51,7 @@ jobs:
       run: make deb
 
     - name: Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cri-dockerd
         retention-days: 5
@@ -78,7 +78,7 @@ jobs:
       run: make rpm
 
     - name: Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cri-dockerd
         retention-days: 5
@@ -105,7 +105,7 @@ jobs:
       run: make cross-arm
 
     - name: Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cri-dockerd
         retention-days: 5
@@ -132,7 +132,7 @@ jobs:
 
     - name: Upload
       if: ${{ github.event_name == 'release' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cri-dockerd
         retention-days: 5
@@ -159,7 +159,7 @@ jobs:
 
     - name: Upload
       if: ${{ github.event_name == 'release' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cri-dockerd
         retention-days: 5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ jobs:
   publish-binaries:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cri-dockerd
       - name: Push binaries


### PR DESCRIPTION
Related: #414 / {#413, #415}

got an email from github:

> `Artifact actions v3` will be `closing` down by `January 30, 2025`. You are receiving this email because you have GitHub Actions workflows using v3 of [actions/upload-artifact](https://app.github.media/e/er?s=88570519&lid=6648&elqTrackId=867ac6c9fa524bda9764f13bec8f8014&elq=bb7fe76f379a4529bd5b6d0a24b4da2f&elqaid=4286&elqat=1&elqak=8AF5D94B629B77D0B2E640E5D18BB16F179524B7B56DEFAF1EFD286953DFC6F749C4) or [actions/download-artifact](https://app.github.media/e/er?s=88570519&lid=6647&elqTrackId=bb54934dfd8c4c44b0e64ec2f2ba4824&elq=bb7fe76f379a4529bd5b6d0a24b4da2f&elqaid=4286&elqat=1&elqak=8AF57B355AADDDE608896B61A68B985ADA8424B7B56DEFAF1EFD286953DFC6F749C4). After this date using v3 of these actions will result in a workflow failure. Artifacts within their retention period will remain accessible from the UI or REST API regardless of the version used to upload.

and found few in my (forked) cri-dockerd repo

n.b.: there are some `breaking changes` in v4 artifact actions actions to be mindful of:
- [upload-artifact](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes)
- [download-artifact](https://github.com/actions/download-artifact?tab=readme-ov-file#breaking-changes)

## Proposed Changes

  - Bump all action/upload-artifact from the deprecated v3 to v4
  - Bump all action/download-artifact from the deprecated v3 to v4
