### PR TITLE
Bump the sandbox image version to 3.10 - backport `release/0.3`

### DIFF
--- a/cmd/cri/options/options.go
+++ b/cmd/cri/options/options.go
@@ -91,7 +91,7 @@ func (f *DockerCRIFlags) AddFlags(mainfs *pflag.FlagSet) {
 
 const (
 	defaultPodSandboxImageName    = "registry.k8s.io/pause"
-	defaultPodSandboxImageVersion = "3.9"
+	defaultPodSandboxImageVersion = "3.10"
 )
 
 var (

--- a/core/sandbox_helpers.go
+++ b/core/sandbox_helpers.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	defaultSandboxImage = "registry.k8s.io/pause:3.9"
+	defaultSandboxImage = "registry.k8s.io/pause:3.10"
 
 	// Various default sandbox resources requests/limits.
 	defaultSandboxCPUshares int64 = 2


### PR DESCRIPTION
* #428 