### PR TITLE
rpm: Change absolute paths to relative paths

### DIFF
--- a/packaging/rpm/SPECS/cri-dockerd.spec
+++ b/packaging/rpm/SPECS/cri-dockerd.spec
@@ -60,11 +60,11 @@ cri-dockerd is a lightweight implementation of the CRI specification which talks
 %setup -q -c -n src -a 0
 
 %build
-cp %{_topdir}/SOURCES/LICENSE /root/rpmbuild/BUILD/src/LICENSE
+cp %{_topdir}/SOURCES/LICENSE LICENSE
 export CRI_DOCKER_GITCOMMIT=%{_gitcommit}
 mkdir -p /go/src/github.com/Mirantis
-ln -s /root/rpmbuild/BUILD/src/app /go/src/github.com/Mirantis/cri-dockerd
-cd /root/rpmbuild/BUILD/src/app
+ln -s $PWD/app /go/src/github.com/Mirantis/cri-dockerd
+cd app
 GOPROXY="https://proxy.golang.org" GO111MODULE=on go build -ldflags "%{_buildldflags}"
 
 %check


### PR DESCRIPTION
The new version of rpm in fc41 now adds a subdirectory.

So the hardcoded paths to BUILD were broken, use relative.

Issue #383
