### PR TITLE
Fix integration test error

### DIFF
--- a/core/helpers_unsupported.go
+++ b/core/helpers_unsupported.go
@@ -35,7 +35,7 @@ func DefaultMemorySwap() int64 {
 }
 
 func (ds *dockerService) getSecurityOpts(
-	seccompProfile *runtimeapi.SecurityProfile,
+	seccompProfile *runtimeapi.SecurityProfile, privileged bool,
 	separator rune,
 ) ([]string, error) {
 	logrus.Info("getSecurityOpts is unsupported in this build")

--- a/core/security_context_linux.go
+++ b/core/security_context_linux.go
@@ -24,9 +24,9 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-func (ds *dockerService) getSecurityOpts(seccomp *runtimeapi.SecurityProfile, separator rune) ([]string, error) {
+func (ds *dockerService) getSecurityOpts(seccomp *runtimeapi.SecurityProfile, privileged bool, separator rune) ([]string, error) {
 	// Apply seccomp options.
-	seccompSecurityOpts, err := getSeccompSecurityOpts(seccomp, separator)
+	seccompSecurityOpts, err := getSeccompSecurityOpts(seccomp, privileged, separator)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate seccomp security options for container: %v", err)
 	}

--- a/core/security_context_windows.go
+++ b/core/security_context_windows.go
@@ -27,6 +27,7 @@ import (
 
 func (ds *dockerService) getSecurityOpts(
 	seccompProfile *v1.SecurityProfile,
+	privileged bool,
 	separator rune,
 ) ([]string, error) {
 	if seccompProfile != nil {


### PR DESCRIPTION
The integration test on master branch has been failing at [seccomp test](https://github.com/kubernetes-sigs/cri-tools/blob/8869f48d4b120b5f775413b2ca7f8073586d08b4/pkg/validate/security_context_linux.go#L891) for months.
It seems to related to new docker version.  

## Proposed Changes
  - Ignore `seccomp` profile that blocks setting hostname when `privileged` is true.
 
