### PR TITLE
[release/0.3] Fix release CI

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   release:
     types: [prereleased]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
 
 jobs:
   vet:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,4 +73,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs/public
 


### PR DESCRIPTION
- Bump `actions/upload-pages-artifact` to `v3` to fix CI failure. 
  - https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
  - https://github.com/actions/upload-pages-artifact/blob/v3/action.yml#L77
- Bump `actions/deploy-page` to `v4` to fix CI failure. 
- Set permissions for `release.yml`
- Add `workflow_dispatch:` to `release.yml` to make debug easier.

Test succeeded in my forked repo: https://github.com/xinfengliu/cri-dockerd/actions/runs/14190283321
