### PR TITLE
[release/0.3] update e2e runner to ubuntu 22.04

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   e2e-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 240
     steps:
 


### PR DESCRIPTION
Ubuntu 20.04 runner will be unavailable on April 15th, 2025. https://github.com/actions/runner-images/issues/11101

## Proposed Changes

  - update e2e runner to ubuntu 22.04
  