### PR TITLE
Replace ubuntu-20.04 with ubuntu-22.04

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   integration:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - name: Checkout cri-dockerd


### PR DESCRIPTION

Fixes integration test. `ubuntu-20.04` is decommissioned in github workflow since Apr 15th, 2025. 
