### PR TITLE
Fix error with docker installation in the integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,11 +35,18 @@ jobs:
       - name: Install docker
         shell: bash
         run: |
-          arch=$(dpkg --print-architecture)
+          # Add Docker's official GPG key:
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
 
-          # Workarounds for error "Failed to fetch https://packagecloud.io/github/git-lfs/ubuntu/dists/trusty/InRelease"
-          # TODO: remove it after the issue fixed in git-lfs.
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
+          # Add the repository to Apt sources:
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
 
           # Install prereqs
@@ -48,20 +55,8 @@ jobs:
             libseccomp2
 
           # Install docker.
-          sudo apt-get install -y \
-            apt-transport-https \
-            ca-certificates \
-            curl socat \
-            gnupg-agent \
-            software-properties-common
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-          sudo add-apt-repository \
-          "deb [arch=$arch] https://download.docker.com/linux/ubuntu \
-           $(lsb_release -cs) \
-           stable"
-          sudo apt-get update
           sudo apt-cache madison docker-ce
-          sudo apt-get install docker-ce docker-ce-cli containerd.io
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io
 
           # Restart docker daemon.
           sudo service docker restart


### PR DESCRIPTION
Fixes the error with docker installation in the integration test of GitHub Action.

## Changes

Following the Docker official doc for installation: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
