### PR TITLE
[release/0.3] Improve docker installation in the integration test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
 
       - name: Checkout cri-dockerd
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.repository }}
           path: src/github.com/Mirantis/cri-dockerd
@@ -91,14 +91,14 @@ jobs:
           sleep 10
 
       - name: Check out kubernetes
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: kubernetes/kubernetes
           path: src/k8s.io/kubernetes
           ref: 84c8abfb8bf900ce36f7ebfbc52794bad972d8cc
 
       - name: Checkout test-infra for kubetest
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: kubernetes/test-infra
           path: src/k8s.io/test-infra

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout cri-dockerd
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.repository }}
           path: src/github.com/Mirantis/cri-dockerd
@@ -71,7 +71,7 @@ jobs:
           sudo cp $(command -v ginkgo) /usr/local/bin
 
       - name: Check out cri-tools
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: kubernetes-sigs/cri-tools
           path: src/sigs.k8s.io/cri-tools
@@ -149,7 +149,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout cri-dockerd
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.repository }}
           path: src/github.com/Mirantis/cri-dockerd

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -58,7 +58,8 @@ jobs:
           # Install docker.
           sudo apt-cache madison docker-ce
           VERSION_STRING=5:26.1.4-1~ubuntu.22.04~jammy
-          sudo apt-get install -y docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io
+          sudo apt-get install -y --allow-downgrades \
+            docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io
 
           # Restart docker daemon.
           sudo service docker restart

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,7 +57,7 @@ jobs:
           # Install docker.
           sudo apt-cache madison docker-ce
           VERSION_STRING=5:26.1.4-1~ubuntu.22.04~jammy
-          sudo apt-get install docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io
+          sudo apt-get install -y docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io
 
           # Restart docker daemon.
           sudo service docker restart

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,11 +35,18 @@ jobs:
       - name: Install docker
         shell: bash
         run: |
-          arch=$(dpkg --print-architecture)
+          # Add Docker's official GPG key:
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
 
-          # Workarounds for error "Failed to fetch https://packagecloud.io/github/git-lfs/ubuntu/dists/trusty/InRelease"
-          # TODO: remove it after the issue fixed in git-lfs.
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
+          # Add the repository to Apt sources:
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
 
           # Install prereqs
@@ -48,18 +55,6 @@ jobs:
             libseccomp2
 
           # Install docker.
-          sudo apt-get install -y \
-            apt-transport-https \
-            ca-certificates \
-            curl socat \
-            gnupg-agent \
-            software-properties-common
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-          sudo add-apt-repository \
-          "deb [arch=$arch] https://download.docker.com/linux/ubuntu \
-           $(lsb_release -cs) \
-           stable"
-          sudo apt-get update
           sudo apt-cache madison docker-ce
           VERSION_STRING=5:26.1.4-1~ubuntu.22.04~jammy
           sudo apt-get install docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,8 +35,14 @@ jobs:
       - name: Install docker
         shell: bash
         run: |
-          # Add Docker's official GPG key:
           sudo apt-get update
+
+          # Install prereqs
+          sudo apt-get install -y \
+            conntrack iptables iproute2 ethtool socat util-linux mount ebtables udev kmod \
+            libseccomp2
+
+          # Add Docker's official GPG key:
           sudo apt-get install -y ca-certificates curl
           sudo install -m 0755 -d /etc/apt/keyrings
           sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
@@ -48,11 +54,6 @@ jobs:
             $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
             sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
-
-          # Install prereqs
-          sudo apt-get install -y \
-            conntrack iptables iproute2 ethtool socat util-linux mount ebtables udev kmod \
-            libseccomp2
 
           # Install docker.
           sudo apt-cache madison docker-ce


### PR DESCRIPTION
Fixes the error with docker installation in the integration test of GitHub Action.

https://github.com/Mirantis/cri-dockerd/actions/runs/15459502887/job/43517856134#step:7:299
```
The following packages will be DOWNGRADED:
  docker-ce docker-ce-cli
E: Packages were downgraded and -y was used without --allow-downgrades.
0 upgraded, 0 newly installed, 2 downgraded, 0 to remove and 71 not upgraded.
Error: Process completed with exit code 100.
```

## Proposed Changes

- Followed the Docker official doc for installation: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
- Added the option `--allow-downgrades` to the `apt-get install` command for docker installation.
- Bump the `checkout` action to v3
