### PR TITLE
Add Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Github code owners
+
+# All .go file changes require the team to review
+*.go @yevchuk-kostiantyn @anaxdev @awmirantis @smerkviladze @mlimardo1984
+
+# Build / infra files
+Makefile @yevchuk-kostiantyn @anaxdev @awmirantis @smerkviladze @mlimardo1984
+
+# Config files
+*.yml @yevchuk-kostiantyn @anaxdev @awmirantis @smerkviladze @mlimardo1984
+*.json @yevchuk-kostiantyn @anaxdev @awmirantis @smerkviladze @mlimardo1984
+*.env @yevchuk-kostiantyn @anaxdev @awmirantis @smerkviladze @mlimardo1984
+
+# Documentation files
+*.md @yevchuk-kostiantyn @anaxdev @awmirantis @smerkviladze @mlimardo1984
+LICENSE @yevchuk-kostiantyn @anaxdev @awmirantis @smerkviladze @mlimardo1984


### PR DESCRIPTION
This PR adds [Codeowners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file.
