### PR TITLE
[release/0.3] Migrate from docker/distribution/reference to distribution/reference

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/davecgh/go-spew v1.1.1
-	github.com/docker/distribution v2.8.1+incompatible
+	github.com/distribution/reference v0.6.0
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/emicklei/go-restful v2.16.0+incompatible
@@ -46,6 +46,7 @@ require (
 	github.com/containerd/cgroups v1.0.1 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
+	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -193,6 +193,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=

--- a/libdocker/helpers.go
+++ b/libdocker/helpers.go
@@ -18,15 +18,16 @@ package libdocker
 
 import (
 	"fmt"
-	"github.com/docker/go-connections/nat"
-	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
-	"k8s.io/kubernetes/pkg/apis/core"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
 
-	dockerref "github.com/docker/distribution/reference"
+	"github.com/docker/go-connections/nat"
+	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/kubernetes/pkg/apis/core"
+
+	dockerref "github.com/distribution/reference"
 	dockertypes "github.com/docker/docker/api/types"
 	godigest "github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
@@ -47,7 +48,7 @@ func ParseDockerTimestamp(s string) (time.Time, error) {
 // (`foo@sha256:xyz`).
 func matchImageTagOrSHA(inspected dockertypes.ImageInspect, image string) bool {
 	// The image string follows the grammar specified here
-	// https://github.com/docker/distribution/blob/master/reference/reference.go#L4
+	// https://github.com/distribution/reference/blob/master/reference.go#L4
 	named, err := dockerref.ParseNormalizedNamed(image)
 	if err != nil {
 		logrus.Errorf("Couldn't parse image (%s) reference: %v", image, err)

--- a/utils/parsers.go
+++ b/utils/parsers.go
@@ -23,7 +23,7 @@ import (
 	//  Import the crypto/sha512 algorithm for the docker image parser to work with 384 and 512 sha hashes
 	_ "crypto/sha512"
 
-	dockerref "github.com/docker/distribution/reference"
+	dockerref "github.com/distribution/reference"
 )
 
 // ParseImageName parses a docker image string into three parts: repo, tag and digest.


### PR DESCRIPTION
Backport of https://github.com/Mirantis/cri-dockerd/pull/473

Not as impactful as on master, as `docker/docker v20.10.17` still contains a reference to the old `docker/distribution`.
