### PR TITLE
Remove direct dependency on deprecated pkg/errors

### DIFF
--- a/backend/daemon_unix.go
+++ b/backend/daemon_unix.go
@@ -3,6 +3,7 @@
 package backend
 
 import (
+	"errors"
 	"net"
 	"os"
 	"os/signal"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/coreos/go-systemd/v22/activation"
 	"github.com/coreos/go-systemd/v22/daemon"
-	"github.com/pkg/errors"
 )
 
 func listenFD(addr string) (net.Listener, error) {

--- a/backend/daemon_windows.go
+++ b/backend/daemon_windows.go
@@ -3,9 +3,8 @@
 package backend
 
 import (
+	"errors"
 	"net"
-
-	"github.com/pkg/errors"
 )
 
 func listenFD(addr string) (net.Listener, error) {

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/opencontainers/runc v1.1.12
 	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/opencontainers/selinux v1.11.0
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
@@ -98,6 +97,7 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect


### PR DESCRIPTION
## Proposed Changes

  - Replace archived [`github.com/pkg/errors`](https://github.com/pkg/errors) with `errors` standard package.
  - Run `go mod tidy`.