### PR TITLE
Fix cross-mac target to use dynamic architecture in output filenames

### DIFF
--- a/packaging/static/Makefile
+++ b/packaging/static/Makefile
@@ -61,9 +61,9 @@ hash_files:
 .PHONY: cross-mac
 cross-mac:
 	mkdir -p build/mac/cri-dockerd
-	cd $(APP_DIR) && env CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=$(ARCH) go build -trimpath ${CRI_DOCKERD_LDFLAGS} -o cri-dockerd-darwin-amd64
-	mv $(APP_DIR)/cri-dockerd-darwin-amd64 build/mac/cri-dockerd/cri-dockerd
-	tar -C build/mac -c -z -f build/mac/cri-dockerd-$(VERSION).darwin.amd64.tgz cri-dockerd
+	cd $(APP_DIR) && env CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=$(ARCH) go build -trimpath ${CRI_DOCKERD_LDFLAGS} -o cri-dockerd-darwin-${ARCH}
+	mv $(APP_DIR)/cri-dockerd-darwin-${ARCH} build/mac/cri-dockerd/cri-dockerd
+	tar -C build/mac -c -z -f build/mac/cri-dockerd-$(VERSION).darwin.${ARCH}.tgz cri-dockerd
 
 .PHONY: cross-win
 cross-win:


### PR DESCRIPTION
Fixes #508

## Proposed Changes

  - When compiling from source, generates the correct name based on the Mac's processor architecture.
