### PR TITLE
Use arm64 arch for Mac packaging

### DIFF
--- a/packaging/static/Makefile
+++ b/packaging/static/Makefile
@@ -61,9 +61,9 @@ hash_files:
 .PHONY: cross-mac
 cross-mac:
 	mkdir -p build/mac/cri-dockerd
-	cd $(APP_DIR) && env CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=$(ARCH) go build -trimpath ${CRI_DOCKERD_LDFLAGS} -o cri-dockerd-darwin-${ARCH}
-	mv $(APP_DIR)/cri-dockerd-darwin-${ARCH} build/mac/cri-dockerd/cri-dockerd
-	tar -C build/mac -c -z -f build/mac/cri-dockerd-$(VERSION).darwin.${ARCH}.tgz cri-dockerd
+	cd $(APP_DIR) && env CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=arm64 go build -trimpath ${CRI_DOCKERD_LDFLAGS} -o cri-dockerd-darwin-arm64
+	mv $(APP_DIR)/cri-dockerd-darwin-arm64 build/mac/cri-dockerd/cri-dockerd
+	tar -C build/mac -c -z -f build/mac/cri-dockerd-$(VERSION).darwin.arm64.tgz cri-dockerd
 
 .PHONY: cross-win
 cross-win:


### PR DESCRIPTION
Fixes #508

## Proposed Changes

Macs don't sell with amd64-compatible processors since 2019. We need to package a binary with arm64-compatible processor
Also, GH action is running on amd64 arch processor. Therefore, this PR forces to use `arm64` arch for packaging Mac binary
