### PR TITLE
[release/0.3] Update package for "errors" compatible with modern Go version

### DIFF
--- a/backend/daemon_unix.go
+++ b/backend/daemon_unix.go
@@ -1,8 +1,10 @@
+//go:build !windows
 // +build !windows
 
 package backend
 
 import (
+	"errors"
 	"net"
 	"os"
 	"os/signal"
@@ -10,7 +12,6 @@ import (
 
 	"github.com/coreos/go-systemd/v22/activation"
 	"github.com/coreos/go-systemd/v22/daemon"
-	"github.com/pkg/errors"
 )
 
 func listenFD(addr string) (net.Listener, error) {

--- a/backend/daemon_windows.go
+++ b/backend/daemon_windows.go
@@ -1,11 +1,11 @@
+//go:build windows
 // +build windows
 
 package backend
 
 import (
+	"errors"
 	"net"
-
-	"github.com/pkg/errors"
 )
 
 func listenFD(addr string) (net.Listener, error) {

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runc v1.2.6
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
@@ -97,6 +96,7 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
 	github.com/opencontainers/selinux v1.11.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect


### PR DESCRIPTION
cherry-pick #497

## Proposed Changes

The `github.com/pkg/errors` package is archived and Legacy Use. No longer maintain.
In Go v1.13+ versions, the `errors` built-in package is recommended.
