### PR TITLE
Add Go build constraint

### DIFF
--- a/backend/daemon_unix.go
+++ b/backend/daemon_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package backend

--- a/backend/daemon_windows.go
+++ b/backend/daemon_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package backend


### PR DESCRIPTION
This PR follows https://github.com/Mirantis/cri-dockerd/pull/497

## Proposed Changes

`//go:build` is used by modern Go versions (1.17+)
`// +build` is kept for older Go versions (<1.17)

This PR adds a Go build constraint which is compatible with modern Go versions