### PR TITLE
[release/0.3] Support packaging of both amd64 and arm64 arch for Mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,10 @@ jobs:
           packaging/static/**/**/**/*.zip
 
   mac:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
     - uses: actions/checkout@v3
 
@@ -155,13 +158,13 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
 
     - name: Build
-      run: make cross-mac
+      run: make ARCH=${{ matrix.arch }} cross-mac
 
     - name: Upload
       if: ${{ github.event_name == 'release' }}
       uses: actions/upload-artifact@v4
       with:
-        name: cri-dockerd.darwin
+        name: cri-dockerd.darwin-${{ matrix.arch }}
         retention-days: 5
         path: |
           packaging/static/**/**/**/*.tgz

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,8 @@ jobs:
           name: cri-dockerd.win
       - uses: actions/download-artifact@v4
         with:
-          name: cri-dockerd.darwin
+          pattern: cri-dockerd.darwin-*
+          merge-multiple: true
       - name: Push binaries
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/packaging/deb/Makefile
+++ b/packaging/deb/Makefile
@@ -3,7 +3,7 @@ include ../common.mk
 APP_DIR:=$(realpath $(CURDIR)/../../)
 GITCOMMIT?=$(shell cd $(APP_DIR) && git rev-parse --short HEAD)
 GO_BASE_IMAGE=golang
-GO_IMAGE=$(GO_BASE_IMAGE):$(GO_VERSION)-bullseye
+GO_IMAGE=$(GO_BASE_IMAGE):$(GO_VERSION)-bookworm
 DEB_VERSION=$(shell ./gen-deb-ver $(APP_DIR) "$(VERSION)")
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 EPOCH?=0

--- a/packaging/rpm/Makefile
+++ b/packaging/rpm/Makefile
@@ -3,7 +3,7 @@ include ../common.mk
 APP_DIR:=$(realpath $(CURDIR)/../../)
 STATIC_VERSION:=$(shell ../static/gen-static-ver $(APP_DIR) $(VERSION))
 GO_BASE_IMAGE=golang
-GO_IMAGE?=$(GO_BASE_IMAGE):$(GO_VERSION)-bullseye
+GO_IMAGE?=$(GO_BASE_IMAGE):$(GO_VERSION)-bookworm
 GEN_RPM_VER=$(shell ./gen-rpm-ver $(APP_DIR) $(VERSION))
 CRI_DOCKER_GITCOMMIT?=$(word 3,$(GEN_RPM_VER))
 CHOWN=docker run --rm -i -v $(CURDIR):/v -w /v alpine chown

--- a/packaging/static/Makefile
+++ b/packaging/static/Makefile
@@ -61,9 +61,9 @@ hash_files:
 .PHONY: cross-mac
 cross-mac:
 	mkdir -p build/mac/cri-dockerd
-	cd $(APP_DIR) && env CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=arm64 go build -trimpath ${CRI_DOCKERD_LDFLAGS} -o cri-dockerd-darwin-arm64
-	mv $(APP_DIR)/cri-dockerd-darwin-arm64 build/mac/cri-dockerd/cri-dockerd
-	tar -C build/mac -c -z -f build/mac/cri-dockerd-$(VERSION).darwin.arm64.tgz cri-dockerd
+	cd $(APP_DIR) && env CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=$(ARCH) go build -trimpath ${CRI_DOCKERD_LDFLAGS} -o cri-dockerd-darwin-$(ARCH)
+	mv $(APP_DIR)/cri-dockerd-darwin-$(ARCH) build/mac/cri-dockerd/cri-dockerd
+	tar -C build/mac -c -z -f build/mac/cri-dockerd-$(VERSION).darwin.$(ARCH).tgz cri-dockerd
 
 .PHONY: cross-win
 cross-win:


### PR DESCRIPTION
Cherry-pick https://github.com/Mirantis/cri-dockerd/pull/519 
(cherry picked from commit 3411765a6767d80707de7b19c2a84c9013e8b27d)

## Proposed Changes
- Add support packaging of both amd64 and arm64 arch for Mac binary
- This PR also fixes the wrong golang image tag in deb/rpm packaging (after bumping Go in https://github.com/Mirantis/cri-dockerd/pull/513) 
