### PR TITLE
Use SHA256 to digest the seccomp profile

### DIFF
--- a/core/security_context.go
+++ b/core/security_context.go
@@ -18,7 +18,7 @@ package core
 
 import (
 	"bytes"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -316,8 +316,8 @@ func getSeccompDockerOpts(seccomp *runtimeapi.SecurityProfile, privileged bool) 
 	if err := json.Compact(b, file); err != nil {
 		return nil, err
 	}
-	// Rather than the full profile, just put the filename & md5sum in the event log.
-	msg := fmt.Sprintf("%s(md5:%x)", fname, md5.Sum(file))
+	// Rather than the full profile, just put the filename & digest in the event log.
+	msg := fmt.Sprintf("%s(sha256:%x)", fname, sha256.Sum256(file))
 
 	return []DockerOpt{{"seccomp", b.String(), msg}}, nil
 }


### PR DESCRIPTION
The MD5 hash algorithm panics under GODEBUG=fips140=only. Calculate the digest of the seccomp profile using SHA256 instead. The message containing the digest is informational only so changing the hash algorithm should not introduce any compatibility breaks. And as far as I can tell the DockerOpt.msg field is a dead store so this change should have no observable impact on behaviour aside from not panicking when run in FIPS140-only mode.
