### PR TITLE
support multi-architecture static builds and artifact publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, s390x, arm, ppc64le]
     steps:
     - uses: actions/checkout@v3
 
@@ -20,13 +23,13 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
 
     - name: Build
-      run: make static-linux
+      run: make ARCH=${{ matrix.arch }} static-linux
 
     - name: Upload
       if: ${{ github.event_name == 'release' }}
       uses: actions/upload-artifact@v4
       with:
-        name: cri-dockerd.ubuntu
+        name: cri-dockerd.linux-${{ matrix.arch }}
         retention-days: 5
         path: |
           packaging/static/**/**/**/*.tgz

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: cri-dockerd.ubuntu
+          pattern: cri-dockerd.linux-*
+          merge-multiple: true
       - uses: actions/download-artifact@v4
         with:
           pattern: cri-dockerd.deb-*

--- a/packaging/static/Makefile
+++ b/packaging/static/Makefile
@@ -51,7 +51,7 @@ static-linux:
 	mkdir -p build/linux/cri-dockerd
 	cd $(APP_DIR) && env CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(ARCH) go build -trimpath ${CRI_DOCKERD_LDFLAGS} -o cri-dockerd
 	mv $(APP_DIR)/cri-dockerd build/linux/cri-dockerd/cri-dockerd
-	tar -C build/linux -c -z -f build/linux/cri-dockerd-$(VERSION).amd64.tgz cri-dockerd
+	tar -C build/linux -c -z -f build/linux/cri-dockerd-$(VERSION).$(ARCH).tgz cri-dockerd
 
 .PHONY: hash_files
 hash_files:


### PR DESCRIPTION
I am minkube's maintainer, and in minikube base image is multi arch, and for a long time we built our own binaries of cir-dockerd because it has been missing s390x, arm, ppc64le archs, this PR tries to add that so we just use the original repo binaries
https://github.com/Mirantis/cri-dockerd/issues/471
