### PR TITLE
fix(network): skip sysctl/modprobe on non-Linux in NoopNetworkPlugin

### DIFF
--- a/network/plugins.go
+++ b/network/plugins.go
@@ -19,6 +19,7 @@ package network
 import (
 	"fmt"
 	"net"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -216,6 +217,10 @@ func (plugin *NoopNetworkPlugin) Init(
 	// correctly.  Other plugins are responsible for setting this correctly
 	// depending on whether or not they connect containers to Linux bridges
 	// or use some other mechanism (ie, SDN vswitch).
+
+	if runtime.GOOS != "linux" {
+		return nil
+	}
 
 	// Ensure the netfilter module is loaded on kernel >= 3.18; previously
 	// it was built-in.

--- a/network/testing/plugins_nonlinux_test.go
+++ b/network/testing/plugins_nonlinux_test.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+/*
+Copyright 2021 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"testing"
+
+	"github.com/Mirantis/cri-dockerd/config"
+	"github.com/Mirantis/cri-dockerd/network"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitNonLinux(t *testing.T) {
+	plug := &network.NoopNetworkPlugin{}
+	// On non-Linux, Init should return immediately without touching sysctl.
+	// If the sysctl path were reached, it would panic because Sysctl is nil.
+	err := plug.Init(NewFakeHost(nil), config.HairpinNone, "10.0.0.0/8", network.UseDefaultMTU)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
NoopNetworkPlugin.Init runs modprobe br-netfilter and sets bridge sysctls unconditionally, which fails on Windows hosts using --network-plugin no-op. Skip them on non-Linux. Fixes #531