### PR TITLE
Add pinned image selectors to exclude images from kubelet GC

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -197,6 +197,8 @@ func RunCriDockerd(f *options.DockerCRIFlags, stopCh <-chan struct{}) error {
 	ds, err := core.NewDockerService(
 		dockerClientConfig,
 		r.PodSandboxImage,
+		r.PinnedImages,
+		r.PinnedImageLabels,
 		streamingConfig,
 		&pluginSettings,
 		f.RuntimeCgroups,

--- a/config/options.go
+++ b/config/options.go
@@ -38,6 +38,16 @@ type ContainerRuntimeOptions struct {
 	// PodSandboxImage is the image whose network/ipc namespaces
 	// containers in each pod will use.
 	PodSandboxImage string
+	// PinnedImages lists image references that are reported to the kubelet as
+	// pinned, which excludes them from kubelet image garbage collection. An
+	// entry may be a full reference ("repo:tag" or "repo@digest"), a bare
+	// repository, which pins every tag of it, or a prefix ending in "*".
+	PinnedImages []string
+	// PinnedImageLabels lists image label selectors, in "key" or "key=value"
+	// form. Any image carrying a matching label is reported to the kubelet as
+	// pinned. This pins a whole set of images without enumerating it, which
+	// matters for images that are side-loaded rather than pulled.
+	PinnedImageLabels []string
 	// DockerEndpoint is the path to the docker endpoint to communicate with.
 	DockerEndpoint string
 	// If no pulling progress is made before the deadline imagePullProgressDeadline,
@@ -105,6 +115,18 @@ func (s *ContainerRuntimeOptions) AddFlags(fs *pflag.FlagSet) {
 		"pod-infra-container-image",
 		s.PodSandboxImage,
 		"The image whose network/ipc namespaces containers in each pod will use",
+	)
+	fs.StringSliceVar(
+		&s.PinnedImages,
+		"pinned-images",
+		s.PinnedImages,
+		"A comma-separated list of images that are never removed by kubelet image garbage collection. An entry may be a full reference, a repository (pinning all of its tags), or a prefix ending in '*'. The pod infra container image is always pinned. May be repeated.",
+	)
+	fs.StringSliceVar(
+		&s.PinnedImageLabels,
+		"pinned-image-labels",
+		s.PinnedImageLabels,
+		"A comma-separated list of image label selectors, in 'key' or 'key=value' form. Images carrying a matching label are never removed by kubelet image garbage collection. May be repeated.",
 	)
 	fs.StringVar(
 		&s.DockerEndpoint,

--- a/core/docker_service.go
+++ b/core/docker_service.go
@@ -118,6 +118,8 @@ var internalLabelKeys = []string{containerTypeLabelKey, containerLogPathLabelKey
 func NewDockerService(
 	clientConfig *config.ClientConfig,
 	podSandboxImage string,
+	pinnedImages []string,
+	pinnedImageLabels []string,
 	streamingConfig *streaming.Config,
 	pluginSettings *config.NetworkPluginSettings,
 	cgroupsName string,
@@ -140,6 +142,7 @@ func NewDockerService(
 		client:          c,
 		os:              config.RealOS{},
 		podSandboxImage: podSandboxImage,
+		pinnedImages:    newPinnedImageMatcher(pinnedImages, pinnedImageLabels),
 		streamingRuntime: &streaming.StreamingRuntime{
 			Client:      client,
 			ExecHandler: &NativeExecHandler{},
@@ -149,6 +152,13 @@ func NewDockerService(
 		networkReady:          make(map[string]bool),
 		containerCleanupInfos: make(map[string]*containerCleanupInfo),
 		containerStatsCache:   newContainerStatsCache(),
+	}
+
+	if !ds.pinnedImages.isEmpty() {
+		logrus.Infof(
+			"Images matching references %v or labels %v are pinned and will not be garbage collected by the kubelet",
+			pinnedImages, pinnedImageLabels,
+		)
 	}
 
 	// check docker version compatibility.
@@ -249,9 +259,12 @@ type dockerService struct {
 	// This handles unimplemented methods unless cri-dockerd overrides them
 	runtimeapi.UnimplementedRuntimeServiceServer
 
-	client           libdocker.DockerClientInterface
-	os               config.OSInterface
-	podSandboxImage  string
+	client          libdocker.DockerClientInterface
+	os              config.OSInterface
+	podSandboxImage string
+	// pinnedImages selects the images reported to the kubelet as pinned, on
+	// top of the pod sandbox image which is always pinned.
+	pinnedImages     *pinnedImageMatcher
 	streamingRuntime *streaming.StreamingRuntime
 	streamingServer  streaming.Server
 

--- a/core/image.go
+++ b/core/image.go
@@ -56,6 +56,20 @@ func isPinned(image string, tags []string) bool {
 	return pinned
 }
 
+// isImagePinned reports whether an image must be reported to the kubelet as
+// pinned, which excludes it from kubelet image garbage collection. The pod
+// sandbox image is always pinned; --pinned-images and --pinned-image-labels
+// pin additional ones.
+func (ds *dockerService) isImagePinned(
+	repoTags, repoDigests []string,
+	labels map[string]string,
+) bool {
+	if isPinned(ds.sandboxImage(), repoTags) {
+		return true
+	}
+	return ds.pinnedImages.matches(repoTags, repoDigests, labels)
+}
+
 // ListImages lists existing images.
 func (ds *dockerService) ListImages(
 	_ context.Context,
@@ -74,11 +88,9 @@ func (ds *dockerService) ListImages(
 	if err != nil {
 		return nil, err
 	}
-	image := ds.sandboxImage()
-
 	result := make([]*runtimeapi.Image, 0, len(images))
 	for _, i := range images {
-		pinned := isPinned(image, i.RepoTags)
+		pinned := ds.isImagePinned(i.RepoTags, i.RepoDigests, i.Labels)
 		apiImage, err := imageToRuntimeAPIImage(&i, pinned)
 		if err != nil {
 			logrus.Infof("Failed to convert docker API image %v to runtime API image: %v", i, err)
@@ -110,7 +122,12 @@ func (ds *dockerService) ImageStatus(
 		}
 	}
 
-	pinned := isPinned(ds.sandboxImage(), imageInspect.RepoTags)
+	var labels map[string]string
+	if imageInspect.Config != nil {
+		labels = imageInspect.Config.Labels
+	}
+
+	pinned := ds.isImagePinned(imageInspect.RepoTags, imageInspect.RepoDigests, labels)
 	imageStatus, err := imageInspectToRuntimeAPIImage(imageInspect, pinned)
 	if err != nil {
 		return nil, err

--- a/core/pinned.go
+++ b/core/pinned.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2026 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import "strings"
+
+// pinnedImageMatcher decides whether a locally present image must be reported
+// to the kubelet as pinned.
+//
+// The kubelet drops pinned images from its eviction list altogether, so
+// pinning is the supported way to keep an image that cannot simply be pulled
+// again -- a platform image side-loaded onto an air-gapped node, say -- from
+// being deleted once the node crosses its image GC threshold.
+//
+// The zero value and a nil matcher match nothing, so callers need no nil check.
+type pinnedImageMatcher struct {
+	// refs holds fully qualified references ("repo:tag" or "repo@digest"),
+	// compared against an image's RepoTags and RepoDigests.
+	refs map[string]struct{}
+	// repos holds bare repositories, which match any tag of that repository.
+	repos map[string]struct{}
+	// prefixes holds the leading portion of patterns written with a trailing
+	// "*", compared against RepoTags and RepoDigests.
+	prefixes []string
+	// labels holds selectors applied to an image's labels.
+	labels []labelSelector
+}
+
+// labelSelector matches an image label by key, and additionally by value when
+// the selector was given in "key=value" form.
+type labelSelector struct {
+	key string
+	// value is only consulted when matchAny is false.
+	value    string
+	matchAny bool
+}
+
+// newPinnedImageMatcher builds a matcher from the operator-supplied image
+// references and label selectors. Blank entries are ignored so that an unset
+// flag, or one holding an empty string, is equivalent to not passing it.
+func newPinnedImageMatcher(refs, labels []string) *pinnedImageMatcher {
+	m := &pinnedImageMatcher{
+		refs:  make(map[string]struct{}),
+		repos: make(map[string]struct{}),
+	}
+
+	for _, ref := range refs {
+		ref = strings.TrimSpace(ref)
+		switch {
+		case ref == "":
+		case strings.HasSuffix(ref, "*"):
+			m.prefixes = append(m.prefixes, strings.TrimSuffix(ref, "*"))
+		case hasTagOrDigest(ref):
+			m.refs[ref] = struct{}{}
+		default:
+			m.repos[ref] = struct{}{}
+		}
+	}
+
+	for _, label := range labels {
+		label = strings.TrimSpace(label)
+		if label == "" {
+			continue
+		}
+		key, value, hasValue := strings.Cut(label, "=")
+		m.labels = append(m.labels, labelSelector{
+			key:      key,
+			value:    value,
+			matchAny: !hasValue,
+		})
+	}
+
+	return m
+}
+
+// isEmpty reports whether the matcher can never match, which lets the caller
+// skip logging about pinning on a default configuration.
+func (m *pinnedImageMatcher) isEmpty() bool {
+	return m == nil ||
+		len(m.refs)+len(m.repos)+len(m.prefixes)+len(m.labels) == 0
+}
+
+// matches reports whether an image carrying the given references and labels
+// should be pinned.
+func (m *pinnedImageMatcher) matches(repoTags, repoDigests []string, labels map[string]string) bool {
+	if m == nil {
+		return false
+	}
+
+	for _, sel := range m.labels {
+		value, ok := labels[sel.key]
+		if ok && (sel.matchAny || value == sel.value) {
+			return true
+		}
+	}
+
+	for _, refs := range [][]string{repoTags, repoDigests} {
+		for _, ref := range refs {
+			if m.matchesRef(ref) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (m *pinnedImageMatcher) matchesRef(ref string) bool {
+	if _, ok := m.refs[ref]; ok {
+		return true
+	}
+	if _, ok := m.repos[refRepository(ref)]; ok {
+		return true
+	}
+	for _, prefix := range m.prefixes {
+		if strings.HasPrefix(ref, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasTagOrDigest reports whether a reference carries a tag or a digest. The
+// colon of a registry port ("localhost:5000/library/nginx") is not a tag, so only
+// the portion after the final slash is considered.
+func hasTagOrDigest(ref string) bool {
+	if strings.Contains(ref, "@") {
+		return true
+	}
+	return strings.Contains(ref[strings.LastIndex(ref, "/")+1:], ":")
+}
+
+// refRepository strips the tag or digest from an image reference, returning it
+// unchanged when it carries neither.
+func refRepository(ref string) string {
+	if i := strings.Index(ref, "@"); i >= 0 {
+		ref = ref[:i]
+	}
+	nameStart := strings.LastIndex(ref, "/") + 1
+	if i := strings.LastIndex(ref[nameStart:], ":"); i >= 0 {
+		ref = ref[:nameStart+i]
+	}
+	return ref
+}

--- a/core/pinned_test.go
+++ b/core/pinned_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 Mirantis
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPinnedImageMatcher(t *testing.T) {
+	const versionLabel = "org.opencontainers.image.version"
+
+	tests := map[string]struct {
+		refs        []string
+		labels      []string
+		repoTags    []string
+		repoDigests []string
+		imageLabels map[string]string
+		want        bool
+	}{
+		"no selectors pins nothing": {
+			repoTags: []string{"nginx:1.27"},
+			want:     false,
+		},
+		"exact reference": {
+			refs:     []string{"nginx:1.27"},
+			repoTags: []string{"nginx:1.27"},
+			want:     true,
+		},
+		"exact reference does not match another tag": {
+			refs:     []string{"nginx:1.27"},
+			repoTags: []string{"nginx:1.28"},
+			want:     false,
+		},
+		"bare repository pins every tag": {
+			refs:     []string{"nginx"},
+			repoTags: []string{"nginx:1.28"},
+			want:     true,
+		},
+		"bare repository does not match a different repository": {
+			refs:     []string{"nginx"},
+			repoTags: []string{"redis:7.4"},
+			want:     false,
+		},
+		"registry port is not mistaken for a tag": {
+			refs:     []string{"localhost:5000/library/nginx"},
+			repoTags: []string{"localhost:5000/library/nginx:1.27"},
+			want:     true,
+		},
+		"prefix pattern": {
+			refs:     []string{"library/ngin*"},
+			repoTags: []string{"library/nginx:1.27"},
+			want:     true,
+		},
+		"prefix pattern does not over-match": {
+			refs:     []string{"library/ngin*"},
+			repoTags: []string{"library/redis:7.4"},
+			want:     false,
+		},
+		"repo digest": {
+			refs:        []string{"nginx@sha256:aaaa"},
+			repoDigests: []string{"nginx@sha256:aaaa"},
+			want:        true,
+		},
+		"untagged image matches nothing by reference": {
+			refs:     []string{"nginx"},
+			repoTags: []string{"<none>:<none>"},
+			want:     false,
+		},
+		"label key matches any value": {
+			labels:      []string{versionLabel},
+			repoTags:    []string{"nginx:1.27"},
+			imageLabels: map[string]string{versionLabel: "1.27"},
+			want:        true,
+		},
+		"label key matches across versions": {
+			labels:      []string{versionLabel},
+			repoTags:    []string{"nginx:1.28"},
+			imageLabels: map[string]string{versionLabel: "1.28"},
+			want:        true,
+		},
+		"label key and value": {
+			labels:      []string{versionLabel + "=1.27"},
+			imageLabels: map[string]string{versionLabel: "1.27"},
+			want:        true,
+		},
+		"label value mismatch": {
+			labels:      []string{versionLabel + "=1.27"},
+			imageLabels: map[string]string{versionLabel: "1.28"},
+			want:        false,
+		},
+		"unlabelled workload image is not pinned": {
+			labels:      []string{versionLabel},
+			repoTags:    []string{"busybox:1.37"},
+			imageLabels: map[string]string{"maintainer": "busybox"},
+			want:        false,
+		},
+		"empty entries are ignored": {
+			refs:     []string{"", "   "},
+			labels:   []string{"", "  "},
+			repoTags: []string{"nginx:1.27"},
+			want:     false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			m := newPinnedImageMatcher(tc.refs, tc.labels)
+			assert.Equal(
+				t,
+				tc.want,
+				m.matches(tc.repoTags, tc.repoDigests, tc.imageLabels),
+			)
+		})
+	}
+}
+
+func TestPinnedImageMatcherIsEmpty(t *testing.T) {
+	var nilMatcher *pinnedImageMatcher
+	assert.True(t, nilMatcher.isEmpty())
+	assert.False(t, nilMatcher.matches([]string{"a:b"}, nil, nil))
+
+	assert.True(t, newPinnedImageMatcher(nil, nil).isEmpty())
+	assert.True(t, newPinnedImageMatcher([]string{""}, []string{" "}).isEmpty())
+	assert.False(t, newPinnedImageMatcher([]string{"a"}, nil).isEmpty())
+	assert.False(t, newPinnedImageMatcher(nil, []string{"k=v"}).isEmpty())
+}
+
+func TestRefRepository(t *testing.T) {
+	tests := map[string]string{
+		"nginx:1.27":                        "nginx",
+		"nginx":                             "nginx",
+		"localhost:5000/library/nginx:1.27": "localhost:5000/library/nginx",
+		"localhost:5000/library/nginx":      "localhost:5000/library/nginx",
+		"nginx@sha256:aaaa":                 "nginx",
+		"registry.k8s.io/pause:3.10":        "registry.k8s.io/pause",
+	}
+	for ref, want := range tests {
+		assert.Equal(t, want, refRepository(ref), ref)
+	}
+}


### PR DESCRIPTION
Fixes #

## Why does this need?

The `kubelet` omits images the runtime reports as pinned from its eviction list, but `cri-dockerd` only ever pinned the pod sandbox image. Any other image that cannot simply be re-pulled -- a platform image side-loaded onto an air-gapped node, for example -- is deleted once the node crosses its image GC threshold.

## Proposed Changes

Add two flags that let an operator pin additional images:

- `--pinned-images` :   image references: a full "repo:tag" or "repo@digest", a bare repository (pinning every tag of it), or a prefix ending in '*'
- `--pinned-image-labels`:   label selectors in "key" or "key=value" form, pinning a whole set of images without enumerating it

Matching lives in a new `pinnedImageMatcher` (core/pinned.go), which `NewDockerService` builds once and `ListImages`/`ImageStatus` consult through `dockerService.isImagePinned`. The sandbox image stays pinned unconditionally, and a nil or empty matcher matches nothing, so the default configuration behaves exactly as before. Reference parsing treats a registry port as part of the repository rather than a tag.

`ImageStatus` now reads labels from the image inspect config so label selectors apply to it as well as to `ListImages`.
